### PR TITLE
WIP: Added modal to Discard Changes

### DIFF
--- a/components/Modal/DiscardChanges.js
+++ b/components/Modal/DiscardChanges.js
@@ -1,0 +1,83 @@
+/* global $ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
+class DiscardChanges extends React.Component {
+  constructor() {
+    super();
+    this.handleDiscard = this.handleDiscard.bind(this);
+    this.handleShowModal = this.handleShowModal.bind(this);
+  }
+
+  componentWillMount() {
+  }
+
+  componentDidMount() {
+    $(this.modal).modal('show');
+    $(this.modal).on('hidden.bs.modal', this.props.handleHideModal);
+  }
+
+  handleDiscard() {
+    $('#cmpsr-modal-discard-changes').modal('hide');
+    this.props.handleDiscardChanges();
+  }
+
+  handleShowModal(e, modalType) {
+    $(this.modal).off('hidden.bs.modal', this.props.handleHideModal);
+    $('#cmpsr-modal-discard-changes').modal('hide');
+    this.props.handleShowModal(e, modalType)
+  }
+
+  render() {
+    return (
+      <div
+        className="modal fade"
+        id="cmpsr-modal-discard-changes"
+        ref={(c) => { this.modal = c; }}
+        tabIndex="-1"
+        role="dialog"
+        aria-labelledby="myModalLabel"
+        aria-hidden="true"
+      >
+        <div className="modal-dialog">
+          <div className="modal-content">
+            <div className="modal-body">
+              <h4 className="modal-title" id="myModalLabel">Are you sure you want to discard pending changes?</h4>
+            </div>
+            <div className="modal-footer">
+              <ul className="list-inline">
+                <li>
+                  <a href="#" onClick={e => this.handleShowModal(e, 'modalPendingChanges')}>View Pending Changes</a>
+                </li>
+                <li>
+                  <button
+                    type="button"
+                    className="btn btn-default"
+                    data-dismiss="modal"
+                  >Cancel</button>
+                </li>
+                <li>
+                  <button type="button" className="btn btn-danger" onClick={() => this.handleDiscard()}>Discard Changes</button>
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+DiscardChanges.propTypes = {
+  modals: PropTypes.object,
+  handleShowModal: PropTypes.func,
+  handleHideModal: PropTypes.func,
+  handleDiscardChanges: PropTypes.func,
+};
+
+const mapStateToProps = state => ({
+  modals: state.modals,
+});
+
+export default connect(mapStateToProps)(DiscardChanges);

--- a/pages/recipeEdit/index.js
+++ b/pages/recipeEdit/index.js
@@ -10,6 +10,7 @@ import ComponentDetailsView from '../../components/ListView/ComponentDetailsView
 import CreateComposition from '../../components/Modal/CreateComposition';
 import ExportRecipe from '../../components/Modal/ExportRecipe';
 import PendingChanges from '../../components/Modal/PendingChanges';
+import DiscardChanges from '../../components/Modal/DiscardChanges';
 import EmptyState from '../../components/EmptyState/EmptyState';
 import Pagination from '../../components/Pagination/Pagination';
 import Toolbar from '../../components/Toolbar/Toolbar';
@@ -407,6 +408,9 @@ class EditRecipePage extends React.Component {
       case 'modalExportRecipe':
         this.props.setModalActive('modalExportRecipe');
         break;
+      case 'modalDiscardChanges':
+        this.props.setModalActive('modalDiscardChanges');
+        break;
       default:
         this.props.setModalActive(null);
         break;
@@ -489,7 +493,7 @@ class EditRecipePage extends React.Component {
               }
               {numPendingChanges > 0 &&
                 <li>
-                  <button className="btn btn-default" type="button" onClick={this.handleDiscardChanges}>
+                  <button className="btn btn-default" type="button" onClick={e => this.handleShowModal(e, 'modalDiscardChanges')}>
                     Discard Changes
                   </button>
                 </li>
@@ -697,6 +701,13 @@ class EditRecipePage extends React.Component {
             recipe={recipe}
             contents={dependencies}
             handleHideModal={this.handleHideModal}
+          />
+          : null}
+        {modalActive === 'modalDiscardChanges'
+          ? <DiscardChanges
+            handleHideModal={this.handleHideModal}
+            handleShowModal={this.handleShowModal}
+            handleDiscardChanges={this.handleDiscardChanges}
           />
           : null}
       </Layout>


### PR DESCRIPTION
When clicking the Discard Changes button a modal will pop up. This modal will give the user the ability to view or discard all of their pending changes. This is a work in progress because the functionality works but the UI needs to be updated.