### PR TITLE
Change when loading states stops showing on Blueprints page

### DIFF
--- a/core/actions/blueprints.js
+++ b/core/actions/blueprints.js
@@ -20,11 +20,6 @@ export const fetchingBlueprints = () => ({
   type: FETCHING_BLUEPRINTS,
 });
 
-export const FETCHING_BLUEPRINT_NAMES_SUCCEEDED = 'FETCHING_BLUEPRINT_NAMES_SUCCEEDED';
-export const fetchingBlueprintNamesSucceeded = () => ({
-  type: FETCHING_BLUEPRINT_NAMES_SUCCEEDED,
-});
-
 export const FETCHING_BLUEPRINTS_SUCCEEDED = 'FETCHING_BLUEPRINTS_SUCCEEDED';
 export const fetchingBlueprintsSucceeded = (blueprint, pendingChanges) => ({
   type: FETCHING_BLUEPRINTS_SUCCEEDED,

--- a/core/reducers/blueprints.js
+++ b/core/reducers/blueprints.js
@@ -1,7 +1,7 @@
 import {
   UNDO, REDO, DELETE_HISTORY,
   CREATING_BLUEPRINT_SUCCEEDED,
-  FETCHING_BLUEPRINTS_SUCCEEDED, FETCHING_BLUEPRINT_NAMES_SUCCEEDED,
+  FETCHING_BLUEPRINTS_SUCCEEDED, 
   FETCHING_BLUEPRINT_CONTENTS_SUCCEEDED,
   ADD_BLUEPRINT_COMPONENT_SUCCEEDED, REMOVE_BLUEPRINT_COMPONENT_SUCCEEDED,
   SET_BLUEPRINT, SET_BLUEPRINT_DESCRIPTION, SET_BLUEPRINT_COMMENT,
@@ -21,11 +21,6 @@ const blueprints = (state = [], action) => {
               future: [],
             }
           ]
-        }
-      );
-    case FETCHING_BLUEPRINT_NAMES_SUCCEEDED:
-      return Object.assign({}, state, {
-          fetchingBlueprints: false,
         }
       );
     // The following reducers filter the blueprint out of the state and add the new version if

--- a/core/sagas/blueprints.js
+++ b/core/sagas/blueprints.js
@@ -7,7 +7,7 @@ import {
   commitToWorkspaceApi, fetchDiffWorkspaceApi,
 } from '../apiCalls';
 import {
-  FETCHING_BLUEPRINTS, fetchingBlueprintsSucceeded, fetchingBlueprintNamesSucceeded,
+  FETCHING_BLUEPRINTS, fetchingBlueprintsSucceeded,
   FETCHING_BLUEPRINT_CONTENTS, fetchingBlueprintContentsSucceeded,
   CREATING_BLUEPRINT, creatingBlueprintSucceeded,
   ADD_BLUEPRINT_COMPONENT, ADD_BLUEPRINT_COMPONENT_SUCCEEDED, addBlueprintComponentSucceeded,
@@ -27,7 +27,6 @@ function* fetchBlueprintsFromName(blueprintName) {
 function* fetchBlueprints() {
   try {
     const blueprintNames = yield call(fetchBlueprintNamesApi);
-    yield put(fetchingBlueprintNamesSucceeded());
     yield* blueprintNames.map(blueprintName => fetchBlueprintsFromName(blueprintName));
   } catch (error) {
     console.log('errorloadBlueprintsSaga');


### PR DESCRIPTION
Modifies actions, reducers and saga for the blueprints page so that the loading state remains on the screen until `FETCHING_BLUEPRINTS_SUCCEEDED` is called.

Closes #305 