### PR TITLE
Pin babel-plugin-react-intl to 3.0.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,6 @@ env:
     - COMMAND=eslint
     - COMMAND=stylelint
     - COMMAND=test_rpmbuild
-    - COMMAND=npm_audit
 script:
   - make "$COMMAND"
 jobs:

--- a/Makefile
+++ b/Makefile
@@ -127,8 +127,3 @@ clean-po:
 	rm po/*.po
 
 .PHONY: tag local-clean vm check devel-install
-
-
-.PHONY: npm_audit
-npm_audit:
-	npm audit

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "babel-eslint": "^10.0.1",
     "babel-loader": "^8.0.5",
     "babel-plugin-istanbul": "^5.1.0",
-    "babel-plugin-react-intl": "^3.0.1",
+    "babel-plugin-react-intl": "3.0.1",
     "babel-plugin-react-intl-auto": "^1.5.0",
     "clean-webpack-plugin": "^1.0.0",
     "connect-history-api-fallback": "^1.2.0",


### PR DESCRIPTION
3.0.2 is broken for us because of

    https://github.com/formatjs/babel-plugin-react-intl/pull/165

`formatMessafe()` calls are not recognized as coming from injectIntl().