### PR TITLE
test:  Initial lorax-composer package index at vm setup stage instead of at test phrase

### DIFF
--- a/test/end-to-end/pages/blueprints.page.js
+++ b/test/end-to-end/pages/blueprints.page.js
@@ -9,7 +9,7 @@ class BlueprintsPage {
   }
 
   loading() {
-    $(this.blueprintListView).waitForExist(timeout * 4);
+    $(this.blueprintListView).waitForExist(timeout);
     browser.waitUntil(() => $$(this.blueprintListView).length >= 3, timeout, "Loading Blueprints page failed");
   }
 

--- a/test/end-to-end/wdio.conf.js
+++ b/test/end-to-end/wdio.conf.js
@@ -5,7 +5,7 @@ const crypto = require("crypto");
 
 // const commands = require('./utils/commands');
 
-const mochaTimeout = parseInt(process.env.MOCHA_TIMEOUT) || 1200000;
+const mochaTimeout = parseInt(process.env.MOCHA_TIMEOUT) || 120000;
 
 exports.config = {
   //

--- a/test/vm.install
+++ b/test/vm.install
@@ -25,5 +25,14 @@ printf "[WebService]\\nAllowUnencrypted=true\\n" > /etc/cockpit/cockpit.conf
 
 # Make cockpit.socket auto-start when system started
 # Do not start it during image generation
-# Do not auto start lorax-composer because it will be enabled in test
 systemctl enable cockpit.socket
+
+# Start lorax-composer to init its db, but do not "enable" it
+# Tests expect the service to not run, it checks the "start service" button
+systemctl start lorax-composer
+
+# wait for lorax-composer initialization before running test
+until curl --unix-socket /run/weldr/api.socket \
+    http://localhost:4000/api/status | grep '"db_supported": *true'; do
+sleep 1;
+done;


### PR DESCRIPTION
1. Start lorax-composer to initial package index at vm setup stage, but not "enable" it to make it inactive when test running. Tests expect the service to not run, it checks the "start service" button
2. Reset all timeout value which changed on PR#639 because test does not need that much time to wait package index initialization