### PR TITLE
test: Add mocha timeout from 2 min to 5 min

### DIFF
--- a/test/end-to-end/wdio.conf.js
+++ b/test/end-to-end/wdio.conf.js
@@ -5,7 +5,7 @@ const crypto = require("crypto");
 
 // const commands = require('./utils/commands');
 
-const mochaTimeout = parseInt(process.env.MOCHA_TIMEOUT) || 120000;
+const mochaTimeout = parseInt(process.env.MOCHA_TIMEOUT) || 300000;
 
 exports.config = {
   //


### PR DESCRIPTION
The page element waiting timeout is 2 min and an error log will be printed in console when element does not appear in timeout. Test should have a longer timeout to have element error log printed