### PR TITLE
test: Click input box before Ctrl-V to make case more stable

### DIFF
--- a/test/end-to-end/specs/viewBlueprint.test.js
+++ b/test/end-to-end/specs/viewBlueprint.test.js
@@ -176,6 +176,7 @@ describe("View Blueprint Page", function() {
         // back to view blueprint page for pasting
         viewBlueprintPage.selectedComponentsTab.click();
         // paste blueprint manifest here to test copy function
+        viewBlueprintPage.selectedComponentFilter.click();
         viewBlueprintPage.selectedComponentFilter.setValue(["Control", "v"]);
         viewBlueprintPage.selectedComponentFilter.waitForValue(timeout);
         expect(viewBlueprintPage.selectedComponentFilter.getValue()).to.equal(blueprintManifest);


### PR DESCRIPTION
The export copy and paste case sometimes failed on Edge browser, add one more step before paste exported content