### PR TITLE
test: Remove maxInstances from capabilities in wdio.conf.js and skip copied content checking on Edge

### DIFF
--- a/test/end-to-end/specs/viewBlueprint.test.js
+++ b/test/end-to-end/specs/viewBlueprint.test.js
@@ -1,6 +1,7 @@
 const faker = require("faker");
 const addContext = require("mochawesome/addContext");
 const commands = require("../utils/commands");
+const wdioConfig = require("../wdio.conf.js");
 
 const Blueprint = require("../components/Blueprint.component");
 const blueprintsPage = require("../pages/blueprints.page");
@@ -173,13 +174,15 @@ describe("View Blueprint Page", function() {
         exportPage.copyButton.click();
         exportPage.closeButton.click();
         browser.waitForExist(exportPage.containerSelector, timeout, true);
-        // back to view blueprint page for pasting
-        viewBlueprintPage.selectedComponentsTab.click();
-        // paste blueprint manifest here to test copy function
-        viewBlueprintPage.selectedComponentFilter.click();
-        viewBlueprintPage.selectedComponentFilter.setValue(["Control", "v"]);
-        viewBlueprintPage.selectedComponentFilter.waitForValue(timeout);
-        expect(viewBlueprintPage.selectedComponentFilter.getValue()).to.equal(blueprintManifest);
+        if (wdioConfig.config.capabilities[0].browserName !== "MicrosoftEdge") {
+          // back to view blueprint page for pasting
+          viewBlueprintPage.selectedComponentsTab.click();
+          // paste blueprint manifest here to test copy function
+          viewBlueprintPage.selectedComponentFilter.click();
+          viewBlueprintPage.selectedComponentFilter.setValue(["Control", "v"]);
+          viewBlueprintPage.selectedComponentFilter.waitForValue(timeout);
+          expect(viewBlueprintPage.selectedComponentFilter.getValue()).to.equal(blueprintManifest);
+        }
       });
     });
   });

--- a/test/end-to-end/wdio.conf.js
+++ b/test/end-to-end/wdio.conf.js
@@ -57,11 +57,6 @@ exports.config = {
   //
   capabilities: [
     {
-      // maxInstances can get overwritten per capability. So if you have an in-house Selenium
-      // grid with only 5 firefox instances available you can make sure that not more than
-      // 5 instances get started at a time.
-      maxInstances: 1,
-      //
       browserName: process.env.BROWSER || "firefox"
     }
   ],


### PR DESCRIPTION
1. The maxInstances in different capability will inherit from up level if it is not configured.
2. Sometimes the Control-v does not work on Edge browser, and there's not a better way to check the copied content. Checking stage in the test will be passed on Edge but still keep clicking copy button part