### PR TITLE
Trim whitespace from SSH keys before saving

### DIFF
--- a/pages/blueprint/index.js
+++ b/pages/blueprint/index.js
@@ -212,7 +212,7 @@ class BlueprintPage extends React.Component {
         name: this.props.userAccount.name
       },
       { ...(this.props.userAccount.description && { description: this.props.userAccount.description }) },
-      { ...(this.props.userAccount.key && { key: this.props.userAccount.key }) },
+      { ...(this.props.userAccount.key && { key: this.props.userAccount.key.trim() }) },
       { ...(this.props.userAccount.groups.includes("wheel") && { groups: ["wheel"] }) }
     );
     if (password) {


### PR DESCRIPTION
Currently, a compose will fail if any of the defined users have newline characters in their SSH key, which is especially unfortunate because SSH public key files like `~/.ssh/id_rsa.pub` typically end with a newline. This patch trims whitespace from both ends of the key so a user can fill out the field by pasting the contents
of an SSH public key file.

See https://github.com/weldr/lorax/pull/752.