### PR TITLE
cockpituous: Fix srpm Release:

### DIFF
--- a/utils/cockpituous-release
+++ b/utils/cockpituous-release
@@ -13,7 +13,7 @@ RELEASE_SRPM="_release/srpm"
 cat ~/.fedora-password | kinit cockpit@FEDORAPROJECT.ORG
 
 job release-source
-job release-srpm
+job release-srpm -V
 
 # Do fedora builds for the tag, using tarball
 job release-koji master


### PR DESCRIPTION
Use release-srpm's `-V` option [1] so that the generated srpm will get a
proper changelog and Release "1" instead of "2".

[1] https://github.com/cockpit-project/cockpituous/commit/abb2bdb5