### PR TITLE
Fix crash if no language is set

### DIFF
--- a/main.js
+++ b/main.js
@@ -35,7 +35,10 @@ if (userLanguage in translations) {
   messages = translations[userLanguage];
 }
 
-const locale_lang = userLanguage.includes("_") ? userLanguage.replace("_", "-") : userLanguage;
+let locale_lang = "en";
+if (userLanguage) {
+  locale_lang = userLanguage.includes("_") ? userLanguage.replace("_", "-") : userLanguage;
+}
 
 function renderComponent(component) {
   ReactDOM.render(


### PR DESCRIPTION
If `cockpit.language` is undefined (which can happen in practice), just
default to English instead of crashing on calling
`undefined.includes()`.