### PR TITLE
Fix images not loading on refresh

### DIFF
--- a/components/ListView/BlueprintListView.js
+++ b/components/ListView/BlueprintListView.js
@@ -12,7 +12,7 @@ class BlueprintListView extends React.PureComponent {
   }
 
   render() {
-    const { blueprints, imageTypes, layout } = this.props;
+    const { blueprints, layout } = this.props;
     return (
       <div className="list-group list-view-pf list-view-pf-view">
         {blueprints.map(blueprint => (
@@ -21,7 +21,7 @@ class BlueprintListView extends React.PureComponent {
               <Link to={`/edit/${blueprint.name}`} className="btn btn-default">
                 <FormattedMessage defaultMessage="Edit Blueprint" />
               </Link>
-              <CreateImage blueprint={blueprint} imageTypes={imageTypes} layout={layout} />
+              <CreateImage blueprint={blueprint} layout={layout} />
               <div className="dropdown pull-right dropdown-kebab-pf">
                 <button
                   className="btn btn-link dropdown-toggle"
@@ -63,7 +63,6 @@ class BlueprintListView extends React.PureComponent {
 
 BlueprintListView.propTypes = {
   blueprints: PropTypes.arrayOf(PropTypes.object),
-  imageTypes: PropTypes.arrayOf(PropTypes.object).isRequired,
   layout: PropTypes.shape({
     setNotifications: PropTypes.func
   })

--- a/components/Modal/CreateImage.js
+++ b/components/Modal/CreateImage.js
@@ -6,7 +6,7 @@ import { connect } from "react-redux";
 import NotificationsApi from "../../data/NotificationsApi";
 import BlueprintApi from "../../data/BlueprintApi";
 import { setBlueprint } from "../../core/actions/blueprints";
-import { fetchingQueue, clearQueue, startCompose } from "../../core/actions/composes";
+import { fetchingQueue, clearQueue, startCompose, fetchingComposeTypes } from "../../core/actions/composes";
 
 const messages = defineMessages({
   infotip: {
@@ -34,6 +34,9 @@ class CreateImageModal extends React.Component {
   }
 
   componentWillMount() {
+    if (this.props.imageTypes.length === 0) {
+      this.props.fetchingComposeTypes();
+    }
     if (this.props.composeQueueFetched === false) {
       this.props.fetchingQueue();
     }
@@ -236,6 +239,7 @@ CreateImageModal.propTypes = {
   fetchingQueue: PropTypes.func.isRequired,
   clearQueue: PropTypes.func.isRequired,
   imageTypes: PropTypes.arrayOf(PropTypes.object).isRequired,
+  fetchingComposeTypes: PropTypes.func.isRequired,
   setBlueprint: PropTypes.func.isRequired,
   intl: intlShape.isRequired,
   startCompose: PropTypes.func.isRequired,
@@ -275,6 +279,7 @@ class CreateImage extends React.Component {
             fetchingQueue={this.props.fetchingQueue}
             clearQueue={this.props.clearQueue}
             imageTypes={this.props.imageTypes}
+            fetchingComposeTypes={this.props.fetchingComposeTypes}
             setBlueprint={this.props.setBlueprint}
             intl={this.props.intl}
             startCompose={this.props.startCompose}
@@ -305,6 +310,7 @@ CreateImage.propTypes = {
   fetchingQueue: PropTypes.func,
   clearQueue: PropTypes.func,
   imageTypes: PropTypes.arrayOf(PropTypes.object),
+  fetchingComposeTypes: PropTypes.func,
   setBlueprint: PropTypes.func,
   intl: intlShape.isRequired,
   startCompose: PropTypes.func,
@@ -320,6 +326,7 @@ CreateImage.defaultProps = {
   fetchingQueue: function() {},
   clearQueue: function() {},
   imageTypes: [],
+  fetchingComposeTypes: function() {},
   setBlueprint: function() {},
   startCompose: function() {},
   layout: {}
@@ -327,12 +334,16 @@ CreateImage.defaultProps = {
 
 const mapStateToProps = state => ({
   composeQueue: state.composes.queue,
-  composeQueueFetched: state.composes.queueFetched
+  composeQueueFetched: state.composes.queueFetched,
+  imageTypes: state.composes.composeTypes
 });
 
 const mapDispatchToProps = dispatch => ({
   setBlueprint: blueprint => {
     dispatch(setBlueprint(blueprint));
+  },
+  fetchingComposeTypes: () => {
+    dispatch(fetchingComposeTypes());
   },
   fetchingQueue: () => {
     dispatch(fetchingQueue());

--- a/core/actions/composes.js
+++ b/core/actions/composes.js
@@ -42,6 +42,11 @@ export const fetchingComposeStatusSucceeded = compose => ({
   }
 });
 
+export const FETCHING_COMPOSE_TYPES = "FETCHING_COMPOSE_TYPES";
+export const fetchingComposeTypes = () => ({
+  type: FETCHING_COMPOSE_TYPES
+});
+
 export const FETCHING_COMPOSE_TYPES_SUCCEEDED = "FETCHING_COMPOSE_TYPES_SUCCEEDED";
 export const fetchingComposeTypesSucceeded = composeTypes => ({
   type: FETCHING_COMPOSE_TYPES_SUCCEEDED,

--- a/core/sagas/composes.js
+++ b/core/sagas/composes.js
@@ -6,8 +6,9 @@ import {
   START_COMPOSE,
   fetchingComposeStatusSucceeded,
   FETCHING_COMPOSES,
-  fetchingComposeTypesSucceeded,
   fetchingComposeSucceeded,
+  FETCHING_COMPOSE_TYPES,
+  fetchingComposeTypesSucceeded,
   composesFailure,
   CANCELLING_COMPOSE,
   DELETING_COMPOSE,
@@ -114,7 +115,7 @@ function* fetchComposeTypes() {
 }
 
 export default function*() {
-  yield* fetchComposeTypes();
+  yield takeEvery(FETCHING_COMPOSE_TYPES, fetchComposeTypes);
   yield takeEvery(START_COMPOSE, startCompose);
   yield takeEvery(FETCHING_COMPOSES, fetchComposes);
   yield takeEvery(DELETING_COMPOSE, deleteCompose);

--- a/pages/blueprint/index.js
+++ b/pages/blueprint/index.js
@@ -306,8 +306,7 @@ class BlueprintPage extends React.Component {
       selectedInputDeps,
       setSelectedInput,
       setSelectedInputParent,
-      clearSelectedInput,
-      imageTypes
+      clearSelectedInput
     } = this.props;
     const { editDescriptionVisible, editHostnameVisible, editHostnameInvalid } = this.props.blueprintPage;
     const { formatMessage } = this.props.intl;
@@ -341,7 +340,7 @@ class BlueprintPage extends React.Component {
                 </Link>
               </li>
               <li>
-                <CreateImage blueprint={blueprint} imageTypes={imageTypes} layout={this.layout} />
+                <CreateImage blueprint={blueprint} layout={this.layout} />
               </li>
               <li>
                 <div className="dropdown dropdown-kebab-pf">
@@ -564,7 +563,7 @@ class BlueprintPage extends React.Component {
                   title={formatMessage(messages.noImagesTitle)}
                   message={formatMessage(messages.noImagesMessage)}
                 >
-                  <CreateImage blueprint={blueprint} imageTypes={imageTypes} layout={this.layout} />
+                  <CreateImage blueprint={blueprint} layout={this.layout} />
                 </EmptyState>
               )) || (
                 <ListView className="cmpsr-images" stacked>
@@ -705,8 +704,7 @@ BlueprintPage.propTypes = {
     url: PropTypes.string
   }),
   blueprintContentsFetching: PropTypes.bool,
-  intl: intlShape.isRequired,
-  imageTypes: PropTypes.arrayOf(PropTypes.object)
+  intl: intlShape.isRequired
 };
 
 BlueprintPage.defaultProps = {
@@ -752,8 +750,7 @@ BlueprintPage.defaultProps = {
   setModalDeleteImageVisible: function() {},
   setModalDeleteImageState: function() {},
   blueprintContentsError: {},
-  blueprintContentsFetching: false,
-  imageTypes: []
+  blueprintContentsFetching: false
 };
 
 const makeMapStateToProps = () => {
@@ -781,7 +778,6 @@ const makeMapStateToProps = () => {
         ),
         createImage: state.modals.createImage,
         userAccount: state.modals.userAccount,
-        imageTypes: state.composes.composeTypes,
         stopBuild: state.modals.stopBuild,
         deleteImage: state.modals.deleteImage,
         componentsSortKey: state.sort.components.key,
@@ -801,7 +797,6 @@ const makeMapStateToProps = () => {
       blueprintPage: state.blueprintPage,
       createImage: state.modals.createImage,
       userAccount: state.modals.userAccount,
-      imageTypes: state.composes.composeTypes,
       stopBuild: state.modals.stopBuild,
       deleteImage: state.modals.deleteImage,
       componentsSortKey: state.sort.components.key,

--- a/pages/blueprintEdit/index.js
+++ b/pages/blueprintEdit/index.js
@@ -380,7 +380,6 @@ class EditBlueprintPage extends React.Component {
       blueprint,
       selectedComponents,
       dependencies,
-      imageTypes,
       inputComponents,
       inputs,
       modalActive,
@@ -468,7 +467,7 @@ class EditBlueprintPage extends React.Component {
                 </li>
               )}
               <li className="list__subgroup-item--first">
-                <CreateImage blueprint={blueprint} imageTypes={imageTypes} layout={this.layout} />
+                <CreateImage blueprint={blueprint} layout={this.layout} />
               </li>
               <li>
                 <div className="dropdown dropdown-kebab-pf">
@@ -753,8 +752,7 @@ EditBlueprintPage.propTypes = {
     url: PropTypes.string
   }),
   blueprintContentsFetching: PropTypes.bool,
-  intl: intlShape.isRequired,
-  imageTypes: PropTypes.arrayOf(PropTypes.object).isRequired
+  intl: intlShape.isRequired
 };
 
 EditBlueprintPage.defaultProps = {
@@ -815,7 +813,6 @@ const makeMapStateToProps = () => {
         componentsSortKey: state.sort.components.key,
         componentsSortValue: state.sort.components.value,
         componentsFilters: state.filter.components,
-        imageTypes: state.composes.composeTypes,
         inputs: state.inputs,
         inputComponents: getSelectedInputs(state, fetchedBlueprint.present.components),
         selectedInput: state.inputs.selectedInput,
@@ -841,7 +838,6 @@ const makeMapStateToProps = () => {
       componentsSortKey: state.sort.components.key,
       componentsSortValue: state.sort.components.value,
       componentsFilters: state.filter.components,
-      imageTypes: state.composes.composeTypes,
       inputs: state.inputs,
       inputComponents: state.inputs.inputComponents,
       selectedInput: state.inputs.selectedInput,

--- a/pages/blueprints/index.js
+++ b/pages/blueprints/index.js
@@ -17,7 +17,6 @@ import {
   blueprintsFilterRemoveValue,
   blueprintsFilterClearValues
 } from "../../core/actions/filter";
-import { startCompose } from "../../core/actions/composes";
 import { makeGetSortedBlueprints, makeGetFilteredBlueprints } from "../../core/selectors";
 
 const messages = defineMessages({
@@ -47,7 +46,6 @@ class BlueprintsPage extends React.Component {
   constructor(props) {
     super(props);
     this.setNotifications = this.setNotifications.bind(this);
-    this.handleStartCompose = this.handleStartCompose.bind(this);
   }
 
   componentWillMount() {
@@ -66,10 +64,6 @@ class BlueprintsPage extends React.Component {
     this.layout.setNotifications();
   }
 
-  handleStartCompose(blueprintName, composeType) {
-    this.props.startCompose(blueprintName, composeType);
-  }
-
   render() {
     const {
       blueprints,
@@ -82,8 +76,7 @@ class BlueprintsPage extends React.Component {
       blueprintsFilterRemoveValue,
       blueprintsFilterClearValues,
       blueprintsError,
-      blueprintsLoading,
-      imageTypes
+      blueprintsLoading
     } = this.props;
     const { formatMessage } = this.props.intl;
     return (
@@ -116,7 +109,6 @@ class BlueprintsPage extends React.Component {
               <BlueprintListView
                 blueprints={blueprints.map(blueprint => blueprint.present)}
                 setNotifications={this.setNotifications}
-                imageTypes={imageTypes}
                 layout={this.layout}
               />
             )) ||
@@ -166,9 +158,7 @@ BlueprintsPage.propTypes = {
     url: PropTypes.string
   }),
   blueprintsLoading: PropTypes.bool,
-  startCompose: PropTypes.func,
-  intl: intlShape.isRequired,
-  imageTypes: PropTypes.arrayOf(PropTypes.object)
+  intl: intlShape.isRequired
 };
 
 BlueprintsPage.defaultProps = {
@@ -184,9 +174,7 @@ BlueprintsPage.defaultProps = {
   blueprintsFilterRemoveValue: function() {},
   blueprintsFilterClearValues: function() {},
   blueprintsError: {},
-  blueprintsLoading: false,
-  startCompose: function() {},
-  imageTypes: []
+  blueprintsLoading: false
 };
 
 const makeMapStateToProps = () => {
@@ -195,7 +183,6 @@ const makeMapStateToProps = () => {
   const mapStateToProps = state => {
     if (getSortedBlueprints(state) !== undefined) {
       return {
-        imageTypes: state.composes.composeTypes,
         manageSources: state.modals.manageSources,
         blueprints: getFilteredBlueprints(state, getSortedBlueprints(state)),
         blueprintSortKey: state.sort.blueprints.key,
@@ -206,7 +193,6 @@ const makeMapStateToProps = () => {
       };
     }
     return {
-      imageTypes: state.composes.composeTypes,
       manageSources: state.modals.manageSources,
       blueprints: state.blueprints.blueprintList,
       blueprintSortKey: state.sort.blueprints.key,
@@ -241,9 +227,6 @@ const mapDispatchToProps = dispatch => ({
   },
   blueprintsFilterClearValues: value => {
     dispatch(blueprintsFilterClearValues(value));
-  },
-  startCompose: (blueprintName, composeType) => {
-    dispatch(startCompose(blueprintName, composeType));
   }
 });
 


### PR DESCRIPTION
This fixes issue #689. 

The fetchComposeTypes saga was blocking other compose sagas from running
on a page refresh. Instead of default calling fetchComposeTypes on the
application loading this saga is now called by a dispatched action.