### PR TITLE
Add notification for source repo deletion

### DIFF
--- a/components/ListView/SourcesListItem.js
+++ b/components/ListView/SourcesListItem.js
@@ -1,6 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { FormattedMessage, defineMessages, injectIntl, intlShape } from "react-intl";
+import { Spinner } from "patternfly-react";
 
 const messages = defineMessages({
   edit: {
@@ -58,39 +59,48 @@ class SourcesListItem extends React.Component {
               </div>
               <div className="list-pf-additional-content text-muted">{source.url}</div>
             </div>
-            {(this.props.edit && (
-              <div className="list-pf-actions">
-                <button
-                  aria-label={`${formatMessage(messages.edit)} ${source.name}`}
-                  className="btn btn-default"
-                  type="button"
-                  ref={this.editButton}
-                  onClick={() => this.props.edit(source.name)}
-                >
-                  <span aria-hidden="true" className="pficon pficon-edit" />
-                </button>
-                <div className="dropdown btn-group dropdown-kebab-pf">
+            {this.props.edit ? (
+              !this.props.fetching ? (
+                <div className="list-pf-actions">
                   <button
-                    aria-label={`${formatMessage(messages.kebab)} ${source.name}`}
-                    className="btn btn-link dropdown-toggle"
+                    aria-label={`${formatMessage(messages.edit)} ${source.name}`}
+                    className="btn btn-default"
                     type="button"
-                    id="dropdownKebab"
-                    data-toggle="dropdown"
-                    aria-haspopup="true"
-                    aria-expanded="false"
+                    ref={this.editButton}
+                    onClick={() => this.props.edit(source.name)}
                   >
-                    <span className="fa fa-ellipsis-v" />
+                    <span aria-hidden="true" className="pficon pficon-edit" />
                   </button>
-                  <ul className="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownKebab">
-                    <li>
-                      <a href="#" onClick={() => this.props.remove(source.name)}>
-                        {formatMessage(messages.remove)}
-                      </a>
-                    </li>
-                  </ul>
+                  <div className="dropdown btn-group dropdown-kebab-pf">
+                    <button
+                      aria-label={`${formatMessage(messages.kebab)} ${source.name}`}
+                      className="btn btn-link dropdown-toggle"
+                      type="button"
+                      id="dropdownKebab"
+                      data-toggle="dropdown"
+                      aria-haspopup="true"
+                      aria-expanded="false"
+                    >
+                      <span className="fa fa-ellipsis-v" />
+                    </button>
+                    <ul className="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownKebab">
+                      <li>
+                        <a href="#" onClick={() => this.props.remove(source.name)}>
+                          {formatMessage(messages.remove)}
+                        </a>
+                      </li>
+                    </ul>
+                  </div>
                 </div>
-              </div>
-            )) || (
+              ) : (
+                <div className="list-pf-actions">
+                  <em className="text-muted">
+                    <Spinner loading size="xs" inline />
+                    <FormattedMessage defaultMessage="Removing source" />
+                  </em>
+                </div>
+              )
+            ) : (
               <div className="list-pf-actions">
                 <em className="text-muted">
                   <FormattedMessage
@@ -115,6 +125,7 @@ SourcesListItem.propTypes = {
   }),
   key: PropTypes.string,
   edited: PropTypes.string,
+  fetching: PropTypes.string,
   edit: PropTypes.func,
   remove: PropTypes.func,
   intl: intlShape.isRequired
@@ -124,6 +135,7 @@ SourcesListItem.defaultProps = {
   source: {},
   key: "",
   edited: "",
+  fetching: false,
   edit: undefined,
   remove: undefined
 };

--- a/components/Modal/ManageSources.js
+++ b/components/Modal/ManageSources.js
@@ -409,6 +409,7 @@ class ManageSourcesModal extends React.Component {
                           source={source}
                           key={source.name}
                           edited={this.state.editName}
+                          fetching={manageSources.fetchingSources}
                           edit={this.handleEditSource}
                           remove={this.props.removeSource}
                         />

--- a/public/custom.css
+++ b/public/custom.css
@@ -231,7 +231,7 @@
   margin-left: 0;
 }
 .cmpsr-list-sources .list-pf-actions {
-  flex-basis: 100px;
+  flex-basis: 150px;
   margin-left: 0;
 }
 @media (min-width: 640px) {


### PR DESCRIPTION
This fixes issue #646

After deleting a source the options to edit  will be replaced by a
spinner and text saying "Deleting source".

![removingSourceScreenshot](https://user-images.githubusercontent.com/11712857/60604358-d1720f80-9db7-11e9-90c2-93dfb7491c8b.png)
