### PR TITLE
updates prop being passed to EmptyState contents

### DIFF
--- a/components/ListView/BlueprintContents.js
+++ b/components/ListView/BlueprintContents.js
@@ -56,7 +56,7 @@ const BlueprintContents = props => {
             title={formatMessage(messages.emptyStateErrorTitle)}
             message={formatMessage(messages.emptyStateErrorMessage)}
           >
-            <p>{errorState.message}</p>
+            <p>{errorState.msg}</p>
             {pastLength > 0 && (
               <button className="btn btn-link btn-lg" type="button" onClick={() => undo()}>
                 <FormattedMessage defaultMessage="Undo Last Change" />


### PR DESCRIPTION
The message that was being passed to the EmptyState for the blueprint components on the Edit Blueprint page was accidentally changed in a previous PR. This PR reverts that change.