### PR TITLE
Fix errorState.msg propType

### DIFF
--- a/components/ListView/BlueprintContents.js
+++ b/components/ListView/BlueprintContents.js
@@ -137,7 +137,7 @@ BlueprintContents.propTypes = {
   filterClearValues: PropTypes.func,
   filterValues: PropTypes.arrayOf(PropTypes.object),
   errorState: PropTypes.shape({
-    message: PropTypes.string,
+    msg: PropTypes.string,
     options: PropTypes.object,
     problem: PropTypes.string,
     url: PropTypes.string


### PR DESCRIPTION
Fixes build failure:

```
components/ListView/BlueprintContents.js
  59:28  error  'errorState.msg' is missing in props validation  react/prop-types
```

This was previously erroneously changed the other way around in commit
56f688dde48dc6, which got reverted in commit 5b38c5efbf.