### PR TITLE
Add additional blueprint name validation

### DIFF
--- a/components/Modal/CreateBlueprint.js
+++ b/components/Modal/CreateBlueprint.js
@@ -255,7 +255,7 @@ class CreateBlueprintModal extends React.Component {
             id="create-blueprint-modal-create-button"
             type="button"
             className="btn btn-primary"
-            disabled={this.state.name.length === 0 || this.nameContainsError()}
+            disabled={this.nameContainsError()}
             onClick={() => this.handleCreateBlueprint()}
           >
             <FormattedMessage defaultMessage="Create" />

--- a/components/Modal/CreateBlueprint.js
+++ b/components/Modal/CreateBlueprint.js
@@ -57,7 +57,7 @@ class CreateBlueprintModal extends React.Component {
       errorNameDuplicate: false,
       errorNameSpace: false,
       errorNameInvalid: false,
-      errorNameInvalidChar: "",
+      errorNameInvalidChar: [],
       errorInline: false,
       name: "",
       description: "",
@@ -114,7 +114,7 @@ class CreateBlueprintModal extends React.Component {
       errorNameSpace: false,
       errorInline: false,
       errorNameInvalid: false,
-      errorNameInvalidChar: ""
+      errorNameInvalidChar: []
     });
   }
 
@@ -122,16 +122,19 @@ class CreateBlueprintModal extends React.Component {
     if (blueprintName.length === 0 && this.state.checkErrors) {
       this.setState({ errorNameEmpty: true });
     } else {
-      const invalidCharsRegex = /[^a-zA-Z0-9._-]/;
-      const nameInvalidChars = blueprintName.search(invalidCharsRegex);
+      // Creates array of unique invalid chars in blueprint name
+      const invalidCharsRegex = /[^a-zA-Z0-9._-\s]/g;
+      const nameInvalidChars = Array.from(new Set(blueprintName.match(invalidCharsRegex)));
       const nameContainsSpace = /\s/.test(blueprintName);
 
-      if (nameInvalidChars !== -1 && !nameContainsSpace) {
+      if (nameInvalidChars.length !== 0) {
         this.setState({ errorNameInvalid: true });
-        this.setState({ errorNameInvalidChar: blueprintName[nameInvalidChars] });
-      } else if (nameContainsSpace) {
+        this.setState({ errorNameInvalidChar: nameInvalidChars });
+      }
+      if (nameContainsSpace) {
         this.setState({ errorNameSpace: true });
-      } else if (this.props.blueprintNames.includes(blueprintName)) {
+      }
+      if (this.props.blueprintNames.includes(blueprintName)) {
         this.setState({ errorNameDuplicate: true });
       }
     }
@@ -206,17 +209,43 @@ class CreateBlueprintModal extends React.Component {
                       }}
                     />
                   )}
-                  {this.state.errorNameSpace && (
+                  {this.state.errorNameSpace && !this.state.errorNameInvalid && (
                     <FormattedMessage defaultMessage="Blueprint names cannot contain spaces." />
                   )}
-                  {this.state.errorNameInvalid && (
-                    <FormattedMessage
-                      defaultMessage="Blueprint names cannot contain {invalidChar}."
-                      values={{
-                        invalidChar: this.state.errorNameInvalidChar
-                      }}
-                    />
-                  )}
+                  {!this.state.errorNameSpace &&
+                    this.state.errorNameInvalid &&
+                    (this.state.errorNameInvalidChar.length === 1 ? (
+                      <FormattedMessage
+                        defaultMessage="Blueprint names cannot contain the character: {invalidChar}"
+                        values={{
+                          invalidChar: this.state.errorNameInvalidChar
+                        }}
+                      />
+                    ) : (
+                      <FormattedMessage
+                        defaultMessage="Blueprint names cannot contain the characters: {invalidChar}"
+                        values={{
+                          invalidChar: this.state.errorNameInvalidChar.join(" ")
+                        }}
+                      />
+                    ))}
+                  {this.state.errorNameSpace &&
+                    this.state.errorNameInvalid &&
+                    (this.state.errorNameInvalidChar.length === 1 ? (
+                      <FormattedMessage
+                        defaultMessage="Blueprint names cannot contain spaces or the character: {invalidChar}"
+                        values={{
+                          invalidChar: this.state.errorNameInvalidChar
+                        }}
+                      />
+                    ) : (
+                      <FormattedMessage
+                        defaultMessage="Blueprint names cannot contain spaces or the characters: {invalidChar}"
+                        values={{
+                          invalidChar: this.state.errorNameInvalidChar.join(" ")
+                        }}
+                      />
+                    ))}
                 </span>
               </div>
             </div>

--- a/components/Modal/CreateBlueprint.js
+++ b/components/Modal/CreateBlueprint.js
@@ -122,7 +122,7 @@ class CreateBlueprintModal extends React.Component {
     if (blueprintName.length === 0 && this.state.checkErrors) {
       this.setState({ errorNameEmpty: true });
     } else {
-      const invalidCharsRegex = /[^a-zA-Z0-9_,.:+*-]/;
+      const invalidCharsRegex = /[^a-zA-Z0-9._-]/;
       const nameInvalidChars = blueprintName.search(invalidCharsRegex);
       const nameContainsSpace = /\s/.test(blueprintName);
 
@@ -138,16 +138,12 @@ class CreateBlueprintModal extends React.Component {
   }
 
   nameContainsError() {
-    if (
+    return (
       this.state.errorNameEmpty ||
       this.state.errorNameDuplicate ||
       this.state.errorNameSpace ||
       this.state.errorNameInvalid
-    ) {
-      return true;
-    } else {
-      return false;
-    }
+    );
   }
 
   render() {

--- a/components/Modal/CreateBlueprint.js
+++ b/components/Modal/CreateBlueprint.js
@@ -52,9 +52,12 @@ class CreateBlueprintModal extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
+      checkErrors: true,
       errorNameEmpty: false,
       errorNameDuplicate: false,
-      checkErrors: true,
+      errorNameSpace: false,
+      errorNameInvalid: false,
+      errorNameInvalidChar: "",
       errorInline: false,
       name: "",
       description: "",
@@ -68,15 +71,15 @@ class CreateBlueprintModal extends React.Component {
     this.setState({ [prop]: e.target.value });
     if (prop === "name") {
       this.dismissErrors();
-      this.handleErrorDuplicate(e.target.value);
+      this.handleErrorNameInvalid(e.target.value);
     }
   }
 
   handleEnterKey(event) {
     if (event.which === 13 || event.keyCode === 13) {
-      this.handleErrors(this.state.name);
+      this.handleErrorNameInvalid(this.state.name);
       setTimeout(() => {
-        if (this.state.errorNameEmpty || this.state.errorNameDuplicate) {
+        if (this.nameContainsError()) {
           this.setState({ errorInline: true });
         } else {
           const blueprint = {
@@ -105,26 +108,45 @@ class CreateBlueprintModal extends React.Component {
   }
 
   dismissErrors() {
-    this.setState({ errorNameEmpty: false, errorNameDuplicate: false, errorInline: false });
+    this.setState({
+      errorNameEmpty: false,
+      errorNameDuplicate: false,
+      errorNameSpace: false,
+      errorInline: false,
+      errorNameInvalid: false,
+      errorNameInvalidChar: ""
+    });
   }
 
-  handleErrors(blueprintName) {
-    this.handleErrorDuplicate(blueprintName);
-    this.handleErrorName(blueprintName);
-  }
+  handleErrorNameInvalid(blueprintName) {
+    if (blueprintName.length === 0 && this.state.checkErrors) {
+      this.setState({ errorNameEmpty: true });
+    } else {
+      const invalidCharsRegex = /[^a-zA-Z0-9_,.:+*-]/;
+      const nameInvalidChars = blueprintName.search(invalidCharsRegex);
+      const nameContainsSpace = /\s/.test(blueprintName);
 
-  handleErrorDuplicate(blueprintName) {
-    const nameNoSpaces = blueprintName.replace(/\s+/g, "-");
-    if (this.props.blueprintNames.includes(nameNoSpaces)) {
-      this.setState({ errorNameDuplicate: true });
+      if (nameInvalidChars !== -1 && !nameContainsSpace) {
+        this.setState({ errorNameInvalid: true });
+        this.setState({ errorNameInvalidChar: blueprintName[nameInvalidChars] });
+      } else if (nameContainsSpace) {
+        this.setState({ errorNameSpace: true });
+      } else if (this.props.blueprintNames.includes(blueprintName)) {
+        this.setState({ errorNameDuplicate: true });
+      }
     }
   }
 
-  handleErrorName(blueprintName) {
-    if (blueprintName === "" && this.state.checkErrors) {
-      setTimeout(() => {
-        this.setState({ errorNameEmpty: true });
-      }, 200);
+  nameContainsError() {
+    if (
+      this.state.errorNameEmpty ||
+      this.state.errorNameDuplicate ||
+      this.state.errorNameSpace ||
+      this.state.errorNameInvalid
+    ) {
+      return true;
+    } else {
+      return false;
     }
   }
 
@@ -138,22 +160,22 @@ class CreateBlueprintModal extends React.Component {
           </Modal.Title>
         </Modal.Header>
         <Modal.Body>
-          {this.state.errorInline && this.state.errorNameEmpty && (
-            <div className="alert alert-danger">
-              <span className="pficon pficon-error-circle-o" />
-              <strong>
-                <FormattedMessage defaultMessage="Required information is missing." />
-              </strong>
-            </div>
-          )}
-          {this.state.errorInline && this.state.errorNameDuplicate && (
-            <div className="alert alert-danger">
-              <span className="pficon pficon-error-circle-o" />
-              <strong>
-                <FormattedMessage defaultMessage="Specify a new blueprint name." />
-              </strong>
-            </div>
-          )}
+          {this.state.errorInline &&
+            ((this.state.errorNameEmpty && (
+              <div className="alert alert-danger">
+                <span className="pficon pficon-error-circle-o" />
+                <strong>
+                  <FormattedMessage defaultMessage="Required information is missing." />
+                </strong>
+              </div>
+            )) || (
+              <div className="alert alert-danger">
+                <span className="pficon pficon-error-circle-o" />
+                <strong>
+                  <FormattedMessage defaultMessage="Specify a new blueprint name." />
+                </strong>
+              </div>
+            ))}
           <form className="form-horizontal">
             <p className="fields-status-pf">
               <FormattedMessage
@@ -163,9 +185,7 @@ class CreateBlueprintModal extends React.Component {
                 }}
               />
             </p>
-            <div
-              className={`form-group ${this.state.errorNameEmpty || this.state.errorNameDuplicate ? "has-error" : ""}`}
-            >
+            <div className={`form-group ${this.nameContainsError() ? "has-error" : ""}`}>
               <label className="col-sm-3 control-label required-pf" htmlFor="textInput-modal-markup">
                 <FormattedMessage defaultMessage="Name" />
               </label>
@@ -176,29 +196,32 @@ class CreateBlueprintModal extends React.Component {
                   id="textInput-modal-markup"
                   className="form-control"
                   value={this.state.name}
-                  onFocus={e => {
-                    this.dismissErrors();
-                    this.handleErrorDuplicate(e.target.value);
-                  }}
                   onChange={e => this.handleChange(e, "name")}
-                  onBlur={e => this.handleErrors(e.target.value)}
+                  onBlur={e => this.handleErrorNameInvalid(e.target.value)}
                   onKeyPress={e => this.handleEnterKey(e)}
                 />
-                {this.state.errorNameEmpty && (
-                  <span className="help-block">
-                    <FormattedMessage defaultMessage="A blueprint name is required." />
-                  </span>
-                )}
-                {this.state.errorNameDuplicate && (
-                  <span className="help-block">
+                <span className="help-block">
+                  {this.state.errorNameEmpty && <FormattedMessage defaultMessage="A blueprint name is required." />}
+                  {this.state.errorNameDuplicate && (
                     <FormattedMessage
                       defaultMessage="The name {name} already exists."
                       values={{
                         name: this.state.name
                       }}
                     />
-                  </span>
-                )}
+                  )}
+                  {this.state.errorNameSpace && (
+                    <FormattedMessage defaultMessage="Blueprint names cannot contain spaces." />
+                  )}
+                  {this.state.errorNameInvalid && (
+                    <FormattedMessage
+                      defaultMessage="Blueprint names cannot contain {invalidChar}."
+                      values={{
+                        invalidChar: this.state.errorNameInvalidChar
+                      }}
+                    />
+                  )}
+                </span>
               </div>
             </div>
             <div className="form-group">
@@ -232,7 +255,7 @@ class CreateBlueprintModal extends React.Component {
             id="create-blueprint-modal-create-button"
             type="button"
             className="btn btn-primary"
-            disabled={this.state.name == "" || this.state.errorNameDuplicate}
+            disabled={this.state.name.length === 0 || this.nameContainsError()}
             onClick={() => this.handleCreateBlueprint()}
           >
             <FormattedMessage defaultMessage="Create" />

--- a/test/end-to-end/specs/createBlueprint.test.js
+++ b/test/end-to-end/specs/createBlueprint.test.js
@@ -40,6 +40,7 @@ describe("Create Blueprints Page", function() {
   it("Create button should be disabled when create blueprint dialog does not have name", function() {
     addContext(this, "cannot create blueprint without name");
     createBlueprintPage.createButton.click();
+    createBlueprintPage.helpBlock.waitForVisible(timeout);
     expect(createBlueprintPage.createButton.getAttribute("disabled")).to.equal("true");
   });
 

--- a/test/end-to-end/specs/createBlueprint.test.js
+++ b/test/end-to-end/specs/createBlueprint.test.js
@@ -39,6 +39,7 @@ describe("Create Blueprints Page", function() {
 
   it("Create button should be disabled when create blueprint dialog does not have name", function() {
     addContext(this, "cannot create blueprint without name");
+    createBlueprintPage.createButton.click();
     expect(createBlueprintPage.createButton.getAttribute("disabled")).to.equal("true");
   });
 


### PR DESCRIPTION
Fixes #317

A user attempting to create a blueprint with spaces or other invalid
charaters in the name will be notified about the invalid character and
prevented from creating the blueprint.