### PR TITLE
Use cockpit's PatternFly CSS with some css updates for composer

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "fastclick": "1.0.6",
     "history": "3.3.0",
     "jquery": "3.4.1",
-    "patternfly": "3.59.3",
     "patternfly-react": "1.19.1",
     "prop-types": "15.7.2",
     "react": "16.8.6",

--- a/public/custom.css
+++ b/public/custom.css
@@ -47,6 +47,7 @@
 }
 .cmpsr-panel__body--main {
   grid-area: edit;
+  background: var(--pf-global--BackgroundColor--100);
 }
 /* Blueprint Edit panel contents */
 .cmpsr-grid__wrapper .cmpsr-panel__body {
@@ -139,6 +140,7 @@
 }
 .cmpsr-title__item {
   margin: 0 10px 0 0;
+  font-size: var(--pf-global--FontSize--2xl);
 }
 
 /* List view */
@@ -303,6 +305,10 @@ the "-" that would display instead of the sr-only "to" */
   top: 10px;
   margin: 0 20px;
 }
+.label-info {
+  background-color: var(--pf-global--link--Color);
+}
+
 /* Expanded list item contents (i.e. component summary) */
 .list-pf-container .list-pf {
   max-height: 300px;
@@ -317,9 +323,9 @@ the "-" that would display instead of the sr-only "to" */
 /*Component details*/
 .pf-icon-small {
     font-size: 1.7rem;
-    height: 30px;
-    line-height: 30px;
-    width: 30px;
+    height: 2.2rem;
+    line-height: 2.2rem;
+    width: 2.2rem;
     display: -webkit-inline-box;
     display: inline-flex;
     -webkit-box-pack: center;
@@ -580,9 +586,12 @@ body {
 }
 
 /* nav-tabs-pf */
- .nav-tabs .badge {
-   display: inline;
- }
+#blueprint-tabs .nav-tabs {
+  margin-top: var(--pf-global--spacer--sm);
+}
+.nav-tabs .badge {
+  display: inline;
+}
 
 /* disabled state */
 /* disable pointer events for both <a> and <button> */

--- a/public/custom.css
+++ b/public/custom.css
@@ -32,9 +32,11 @@
 .cmpsr-panel__title--sidebar {
   grid-area: inputsTitle;
   margin-right: -1px;
+  margin-left: 20px;
 }
 .cmpsr-panel__title--main {
   grid-area: editTitle;
+  margin-right: 20px;
 }
 .cmpsr-panel__body {
   border-width: 0 1px 1px;
@@ -44,10 +46,12 @@
 .cmpsr-panel__body--sidebar {
   grid-area: inputs;
   margin-right: -1px;
+  margin-left: 20px;
 }
 .cmpsr-panel__body--main {
   grid-area: edit;
   background: var(--pf-global--BackgroundColor--100);
+  margin-right: 20px;
 }
 /* Blueprint Edit panel contents */
 .cmpsr-grid__wrapper .cmpsr-panel__body {
@@ -623,4 +627,12 @@ textarea.form-control[readonly] {
   position: sticky;
   top: 0;
   background: #fff;
+}
+
+/* PF4 styles for PF3 classes */
+body {
+  background: var(--pf-global--BackgroundColor--100);
+}
+.container-fluid {
+  padding: 0 20px;
 }

--- a/public/custom.css
+++ b/public/custom.css
@@ -144,6 +144,8 @@
 }
 .cmpsr-title__item {
   margin: 0 10px 0 0;
+}
+h1.cmpsr-title__item {
   font-size: var(--pf-global--FontSize--2xl);
 }
 
@@ -635,4 +637,11 @@ body {
 }
 .container-fluid {
   padding: 0 20px;
+}
+
+.fields-status-pf {
+  color: var(--pf-global--Color--200);
+}
+.text-muted {
+  color: var(--pf-global--Color--200);
 }

--- a/public/index.ejs
+++ b/public/index.ejs
@@ -3,8 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>Cockpit-Composer</title>
-    <link rel="stylesheet" href="./css/patternfly.min.css">
-    <link rel="stylesheet" href="./css/patternfly-additions.min.css">
+    <link rel="stylesheet" href="../base1/patternfly.css">
     <link rel="stylesheet" href="./custom.css">
 
     <!-- js dependencies -->

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -24,21 +24,8 @@ const plugins = [
     $: "jquery",
     jQuery: "jquery"
   }),
-  // copy patternfly assets
+  // copy our assets
   new CopyWebpackPlugin([
-    {
-      from: { glob: "./node_modules/patternfly/dist/fonts/*.*" },
-      to: "./fonts",
-      flatten: true
-    },
-    {
-      from: "./node_modules/patternfly/dist/css/patternfly.min.css",
-      to: "./css"
-    },
-    {
-      from: "./node_modules/patternfly/dist/css/patternfly-additions.min.css",
-      to: "./css"
-    },
     {
       from: "./public/custom.css"
     },


### PR DESCRIPTION
This takes updates made in https://github.com/weldr/cockpit-composer/pull/700 and adds a few miscellaneous css updates in the context of Composer custom css updates.

There were a couple of items provided in the cockpit css that didn't have sufficient color contrast. I updated those here, but it might be worth checking if these are used in cockpit, and if the color contrast issues are present there as well.
```
.fields-status-pf { 	
  color: #8b8d8f;
  margin-bottom: 15px;
}
```
 I updated this in composer to `var(--pf-global--Color--200);`

```
.label-info { 
  background-color: #73bcf7;
}
```
 I updated this in composer to `var(--pf-global--link--Color)`