### PR TITLE
Fix AppStream ID

### DIFF
--- a/io.weldr.cockpit-composer.metainfo.xml
+++ b/io.weldr.cockpit-composer.metainfo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="addon">
-  <id>io.weldr.cockpit-composer</id>
+  <id>io.weldr.cockpit_composer</id>
   <metadata_license>CC0-1.0</metadata_license>
   <name>Image Builder</name>
   <summary>
@@ -12,6 +12,6 @@
       systems, or as images ready to upload to the cloud.
     </p>
   </description>
-  <extends>cockpit.desktop</extends>
+  <extends>org.cockpit_project.cockpit</extends>
   <launchable type="cockpit-manifest">welder</launchable>
 </component>


### PR DESCRIPTION
Cockpit renamed its ID to "org.cockpit_project.cockpit" to conform to
the AppStream spec [1]. Follow suit and also fix our own ID to not
contain hyphens.

[1] https://github.com/cockpit-project/cockpit/commit/4a9ffe669c