### PR TITLE
Fix wrong PropType for homepage

### DIFF
--- a/components/ListView/ListItemComponents.js
+++ b/components/ListView/ListItemComponents.js
@@ -169,7 +169,7 @@ ListItemComponents.propTypes = {
     ui_type: PropTypes.string,
     userSelected: PropTypes.bool,
     version: PropTypes.string,
-    homepage: PropTypes.arrayOf(PropTypes.string),
+    homepage: PropTypes.string,
     dependencies: PropTypes.arrayOf(PropTypes.object)
   }),
   listItemParent: PropTypes.string,


### PR DESCRIPTION
Homepage is always returned as a single string from the API.