### PR TITLE
Convert to standard plugin

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -4,11 +4,9 @@
         "cockpit": "134"
     },
 
-    "dashboard": {
+    "tools": {
         "index": {
-            "label": "Image Builder",
-            "order": 30,
-            "icon": "pficon-build"
+            "label": "Image Builder"
         }
     },
     "content-security-policy": "default-src 'self' 'unsafe-eval'"


### PR DESCRIPTION
Someone mentioned that this would make sense, so I am opening this PR to start some discussion.
The main reasoning is that the backend runs on a machine, so if you switch to other machine this plugin can disappear/appear/change.
What do you @martinpitt @larskarlitski think?

![downthere](https://user-images.githubusercontent.com/12330670/62942637-fefba100-bdd8-11e9-9ce6-cc6de0f91a41.png)
