### PR TITLE
Use virtio-net instead of rtl8139 network cards for test

### DIFF
--- a/test/check-application
+++ b/test/check-application
@@ -54,7 +54,9 @@ def run_webdriver_tests(machine, env=[]):
 
 def run_e2e(verbose, image, browser, cpus, memory, sit):
     # settings on composer VM
-    network = testvm.VirtNetwork(0)
+
+    # When Windows in use, we need rtl8139, for anything else we want virtio-net-pci
+    network = testvm.VirtNetwork(0, image="windows-10" if "edge" in browser else image)
     composer = testvm.VirtMachine(verbose=verbose, image=image,
                                   networking=network.host(),
                                   memory_mb=memory, cpus=cpus)


### PR DESCRIPTION
See https://github.com/cockpit-project/cockpit/pull/12569

Mind you, this will fail now, since `VirtNetwork` does not have `image` argument in constructor.
However without this change https://github.com/cockpit-project/cockpit/pull/12569 fails.
There is no way how to test PR in external project from PR in Cockpit :)

It would be awesome if @henrywang could test it together with https://github.com/cockpit-project/cockpit/pull/12569.
When this is approved I would prefer to first merge https://github.com/cockpit-project/cockpit/pull/12569 and then this PR (since if this is first merged nothing can be tested here, but on cockpit it blocks much less things)