### PR TITLE
Remove @babel/polyfill, use core-js and regenerator-runtime instead

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   presets: [
     [
-      "@babel/env",
+      "@babel/preset-env",
       {
         targets: {
           chrome: "57",

--- a/main.js
+++ b/main.js
@@ -1,3 +1,7 @@
+import "core-js/stable";
+// redux-saga uses generators, use regenerator-runtime/runtime to transform generators
+import "regenerator-runtime/runtime";
+
 import "whatwg-fetch";
 
 import React from "react";

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "npm": ">=5.0"
   },
   "dependencies": {
-    "@babel/polyfill": "7.6.0",
     "bootstrap": "3.4.1",
+    "core-js": "3.2.1",
     "fastclick": "1.0.6",
     "history": "3.3.0",
     "jquery": "3.4.1",
@@ -20,6 +20,7 @@
     "react-redux": "5.1.1",
     "redux": "3.7.2",
     "redux-saga": "0.15.6",
+    "regenerator-runtime": "0.13.3",
     "reselect": "3.0.1",
     "shortid": "2.2.15",
     "whatwg-fetch": "1.1.1"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -47,8 +47,7 @@ const plugins = [
 
 module.exports = {
   mode: mode,
-  // redux-saga uses generators, babel compiles using regenerator runtime included in @babel/polyfill
-  entry: ["@babel/polyfill", "./main.js"],
+  entry: "./main.js",
   plugins: plugins,
   output: output,
   devtool: devtool,


### PR DESCRIPTION
According to https://babeljs.io/docs/en/next/babel-polyfill, @babel/polyfill has been deprecated in Babel 7.4.0.