### PR TITLE
Makefile: Update bots target for moved GitHub project

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,12 +112,14 @@ check: $(VM_IMAGE)
 debug-check:
 	DEBUG_TEST=true $(MAKE) check
 
-# checkout Cockpit's bots/ directory for standard test VM images and API to launch them
-# must be from cockpit's master, as only that has current and existing images; but testvm.py API is stable
+# checkout Cockpit's bots for standard test VM images and API to launch them
+# must be from master, as only that has current and existing images; but testvm.py API is stable
 bots:
-	git fetch --depth=1 https://github.com/cockpit-project/cockpit.git
-	git checkout --force FETCH_HEAD -- bots/
-	git reset bots
+	if [ ! -d bots ]; then \
+		git clone --depth=1 https://github.com/cockpit-project/bots.git; \
+	else \
+		cd bots && git fetch && git reset --hard origin/master; \
+        fi
 
 # The po-refresh bot expects these specific Makefile targets
 update-po:
@@ -126,4 +128,4 @@ download-po: po-pull
 clean-po:
 	rm po/*.po
 
-.PHONY: tag local-clean vm check devel-install
+.PHONY: tag local-clean vm check devel-install bots


### PR DESCRIPTION
Cockpit bots are in their own project now.

Make the target phony so that `make bots` updates an existing checkout.