### PR TITLE
Makefile: Don't clobber an existing bots checkout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,11 +115,7 @@ debug-check:
 # checkout Cockpit's bots for standard test VM images and API to launch them
 # must be from master, as only that has current and existing images; but testvm.py API is stable
 bots:
-	if [ ! -d bots ]; then \
-		git clone --depth=1 https://github.com/cockpit-project/bots.git; \
-	else \
-		cd bots && git fetch && git reset --hard origin/master; \
-        fi
+	[ -d bots ] || git clone --depth=1 https://github.com/cockpit-project/bots.git
 
 # The po-refresh bot expects these specific Makefile targets
 update-po:


### PR DESCRIPTION
Commit e6115d5215 (originally introduced by me into starter-kit) is a
thinko -- for our CI we *don't* want our test to clobber a pre-existing
bots/ checkout, as we often use this to run tests against an updated
image or to validate a changes to the bots project.

On developer machines, bots may also be a symlink to an actual bots
directory in development, so don't clobber that.