### PR TITLE
Update deprecated lifecycle methods

### DIFF
--- a/components/Layout/Layout.js
+++ b/components/Layout/Layout.js
@@ -10,7 +10,7 @@ class Layout extends React.Component {
     this.setNotifications = this.setNotifications.bind(this);
   }
 
-  componentWillMount() {
+  componentDidMount() {
     this.setNotifications();
   }
 

--- a/components/ListView/BlueprintContents.js
+++ b/components/ListView/BlueprintContents.js
@@ -83,7 +83,6 @@ const BlueprintContents = props => {
                   <ListView className="cmpsr-blueprint__components" stacked>
                     {components.map(listItem => (
                       <ListItemComponents
-                        listItemParent="cmpsr-blueprint__components"
                         listItem={listItem}
                         key={listItem.name}
                         handleRemoveComponent={handleRemoveComponent}

--- a/components/ListView/DependencyListView.js
+++ b/components/ListView/DependencyListView.js
@@ -4,9 +4,7 @@ import PropTypes from "prop-types";
 import ListView from "./ListView";
 import ListItemComponents from "./ListItemComponents";
 
-class DependencyListView extends React.Component {
-  componentWillMount() {}
-
+class DependencyListView extends React.PureComponent {
   render() {
     return (
       <div>
@@ -21,7 +19,6 @@ class DependencyListView extends React.Component {
         <ListView className={this.props.className} stacked>
           {this.props.listItems.map(listItem => (
             <ListItemComponents
-              listItemParent={this.props.className}
               isDependency
               listItem={listItem}
               key={listItem.name}

--- a/components/ListView/ListItemComponents.js
+++ b/components/ListView/ListItemComponents.js
@@ -10,22 +10,9 @@ class ListItemComponents extends React.Component {
     this.state = { expanded: false };
   }
 
-  componentWillReceiveProps(newProps) {
-    // compare old value to new value, and if this component is getting new data,
-    // then get the current expand state of the new value as it is in the old dom
-    // and apply that expand state to this component
-    const olditem = this.props.listItem.name;
-    const newitem = newProps.listItem.name;
-    const parent = this.props.listItemParent;
-    if (olditem !== newitem) {
-      if ($(`.${parent} [data-component="${newitem.name}"]`).hasClass("active")) {
-        this.setState({ expanded: true });
-      } else {
-        this.setState({ expanded: false });
-      }
-    }
-    if (this.state.expanded === true && newProps.listItem.dependencies === undefined) {
-      this.props.fetchDetails(newProps.listItem);
+  componentDidUpdate(prevProps, prevState) {
+    if (prevState.expanded === true && this.props.listItem.dependencies === undefined) {
+      this.props.fetchDetails(this.props.listItem);
     }
   }
 
@@ -169,7 +156,6 @@ ListItemComponents.propTypes = {
     homepage: PropTypes.string,
     dependencies: PropTypes.arrayOf(PropTypes.object)
   }),
-  listItemParent: PropTypes.string,
   componentDetailsParent: PropTypes.shape({
     active: PropTypes.bool,
     group_type: PropTypes.string,
@@ -191,7 +177,6 @@ ListItemComponents.propTypes = {
 
 ListItemComponents.defaultProps = {
   listItem: {},
-  listItemParent: "",
   componentDetailsParent: {},
   handleComponentDetails: function() {},
   handleRemoveComponent: function() {},

--- a/components/Modal/CreateImage.js
+++ b/components/Modal/CreateImage.js
@@ -33,7 +33,7 @@ class CreateImageModal extends React.Component {
     this.setNotifications = this.setNotifications.bind(this);
   }
 
-  componentWillMount() {
+  componentDidMount() {
     if (this.props.imageTypes.length === 0) {
       this.props.fetchingComposeTypes();
     }

--- a/components/Modal/EditDescription.js
+++ b/components/Modal/EditDescription.js
@@ -54,7 +54,7 @@ class EditDescriptionModal extends React.Component {
     this.handleSubmit = this.handleSubmit.bind(this);
   }
 
-  componentWillMount() {
+  componentDidMount() {
     this.setState({ description: this.props.description });
   }
 

--- a/components/Modal/PendingChanges.js
+++ b/components/Modal/PendingChanges.js
@@ -39,11 +39,8 @@ class PendingChanges extends React.Component {
     this.handleCommitChanges = this.handleCommitChanges.bind(this);
   }
 
-  componentWillMount() {
-    this.setState({ comment: this.props.blueprint.comment });
-  }
-
   componentDidMount() {
+    this.setState({ comment: this.props.blueprint.comment });
     $(this.modal).modal("show");
     $(this.modal).on("hidden.bs.modal", this.props.handleHideModal);
   }

--- a/components/Notifications/Notification.js
+++ b/components/Notifications/Notification.js
@@ -9,7 +9,7 @@ class Notification extends React.PureComponent {
     this.timeouts = [];
   }
 
-  componentWillMount() {
+  componentDidMount() {
     this.setFade(this.props.notification.fade);
     if (this.props.notification.type === "process") {
       this.timeouts.push(
@@ -24,8 +24,8 @@ class Notification extends React.PureComponent {
     }
   }
 
-  componentWillReceiveProps(nextProps) {
-    this.setFade(nextProps.notification.fade);
+  componentDidUpdate() {
+    this.setFade(this.props.notification.fade);
   }
 
   componentWillUnmount() {

--- a/components/Pagination/Pagination.js
+++ b/components/Pagination/Pagination.js
@@ -26,17 +26,20 @@ class Pagination extends React.Component {
     this.handleChange = this.handleChange.bind(this);
   }
 
-  componentWillMount() {
+  componentDidMount() {
     this.setState({ pageValue: this.props.currentPage });
   }
 
-  componentWillReceiveProps(newProps) {
-    this.setState({ pageValue: newProps.currentPage });
-    // If the input has focus when the page value is updated, then select the
-    // text
+  componentDidUpdate() {
     if (this.paginationPage === document.activeElement) {
       this.paginationPage.select();
     }
+  }
+
+  static getDerivedStateFromProps(newProps, prevState) {
+    if (prevState.pageValue !== newProps.currentPage) {
+      return { pageValue: newProps.currentPage };
+    } else return null;
   }
 
   handleBlur() {

--- a/components/Toolbar/FilterInput.js
+++ b/components/Toolbar/FilterInput.js
@@ -14,7 +14,7 @@ class FilterInput extends React.Component {
     this.selectFilterType = this.selectFilterType.bind(this);
   }
 
-  componentWillMount() {
+  componentDidMount() {
     this.setState({ currentFilterId: this.props.filters.defaultFilterType });
   }
 
@@ -46,23 +46,25 @@ class FilterInput extends React.Component {
         <div className="filter-pf-fields">
           <div className="form-group toolbar-pf-filter">
             <div className="input-group">
-              {filters.filterTypes.length > 1 && (
+              {currentFilterType !== undefined && filters.filterTypes.length > 1 && (
                 <Filter.TypeSelector
                   filterTypes={filters.filterTypes}
                   currentFilterType={currentFilterType}
                   onFilterTypeSelected={this.selectFilterType}
                 />
               )}
-              <input
-                onChange={this.handleChangeFilter}
-                disabled={emptyState}
-                type="text"
-                className="form-control"
-                id="filter-blueprints"
-                value={this.state.filterValue}
-                placeholder={`${currentFilterType.placeholder}...`}
-                aria-label={currentFilterType.placeholder}
-              />
+              {currentFilterType !== undefined && (
+                <input
+                  onChange={this.handleChangeFilter}
+                  disabled={emptyState}
+                  type="text"
+                  className="form-control"
+                  id="filter-blueprints"
+                  value={this.state.filterValue}
+                  placeholder={`${currentFilterType.placeholder}...`}
+                  aria-label={currentFilterType.placeholder}
+                />
+              )}
             </div>
           </div>
         </div>

--- a/pages/blueprint/index.js
+++ b/pages/blueprint/index.js
@@ -142,7 +142,10 @@ class BlueprintPage extends React.Component {
     this.downloadUrl = this.downloadUrl.bind(this);
   }
 
-  componentWillMount() {
+  componentDidMount() {
+    const { formatMessage } = this.props.intl;
+    document.title = formatMessage(messages.blueprint);
+
     if (this.props.blueprint.components === undefined) {
       this.props.fetchingBlueprintContents(this.props.route.params.blueprint.replace(/\s/g, "-"));
     }
@@ -151,11 +154,6 @@ class BlueprintPage extends React.Component {
     }
     this.props.setEditDescriptionVisible(false);
     this.props.setEditHostnameVisible(false);
-  }
-
-  componentDidMount() {
-    const { formatMessage } = this.props.intl;
-    document.title = formatMessage(messages.blueprint);
   }
 
   componentWillUnmount() {

--- a/pages/blueprint/index.js
+++ b/pages/blueprint/index.js
@@ -282,7 +282,6 @@ class BlueprintPage extends React.Component {
 
   render() {
     if (this.props.blueprint.components === undefined) {
-      this.props.fetchingBlueprintContents(this.props.route.params.blueprint.replace(/\s/g, "-"));
       return <div />;
     }
     const {

--- a/pages/blueprintEdit/index.js
+++ b/pages/blueprintEdit/index.js
@@ -96,7 +96,9 @@ class EditBlueprintPage extends React.Component {
     this.handleUndo = this.handleUndo.bind(this);
   }
 
-  componentWillMount() {
+  componentDidMount() {
+    const { formatMessage } = this.props.intl;
+    document.title = formatMessage(messages.blueprintTitle);
     // get blueprint, get inputs; then update inputs
     if (this.props.blueprint.components === undefined) {
       this.props.fetchingBlueprintContents(this.props.route.params.blueprint.replace(/\s/g, "-"));
@@ -104,11 +106,6 @@ class EditBlueprintPage extends React.Component {
     } else {
       this.props.fetchingInputs(this.props.inputs.inputFilters, 0, 50);
     }
-  }
-
-  componentDidMount() {
-    const { formatMessage } = this.props.intl;
-    document.title = formatMessage(messages.blueprintTitle);
   }
 
   componentWillUnmount() {

--- a/pages/blueprintEdit/index.js
+++ b/pages/blueprintEdit/index.js
@@ -372,7 +372,6 @@ class EditBlueprintPage extends React.Component {
 
   render() {
     if (this.props.blueprint.id === undefined) {
-      this.props.fetchingBlueprintContents(this.props.route.params.blueprint.replace(/\s/g, "-"));
       return <div />;
     }
     const blueprintDisplayName = this.props.route.params.blueprint;

--- a/pages/blueprints/index.js
+++ b/pages/blueprints/index.js
@@ -48,16 +48,14 @@ class BlueprintsPage extends React.Component {
     this.setNotifications = this.setNotifications.bind(this);
   }
 
-  componentWillMount() {
+  componentDidMount() {
+    const { formatMessage } = this.props.intl;
+    document.title = formatMessage(messages.blueprintsTitle);
+
     if (this.props.blueprintsLoading === true) {
       this.props.fetchingBlueprints();
       this.props.fetchingModalManageSourcesContents();
     }
-  }
-
-  componentDidMount() {
-    const { formatMessage } = this.props.intl;
-    document.title = formatMessage(messages.blueprintsTitle);
   }
 
   setNotifications() {


### PR DESCRIPTION
In React 17 componentWillMount, componentWillUpdate, and componentWillReceieveProps are deprecated. The functionality triggered by these hooks has been updated and moved to other methods.