### PR TITLE
Use dnf instead of yum in Fedora to support Fedora 31 and use command -v instead of which

### DIFF
--- a/test/vm.install
+++ b/test/vm.install
@@ -15,7 +15,7 @@ if type firewall-cmd >/dev/null 2>&1; then
 fi
 
 # Install nodejs if it does not exist
-which node > /dev/null 2>&1 || yum install -y nodejs
+command -v node > /dev/null 2>&1 || $(command -v dnf || command -v yum) install -y nodejs
 
 # disable https in cockpit and use http instead
 printf "[WebService]\\nAllowUnencrypted=true\\n" > /etc/cockpit/cockpit.conf


### PR DESCRIPTION
The `yum` has been removed since Fedora 31.
https://fedoraproject.org/wiki/Releases/31/ChangeSet#Retire_YUM_3
Solution is use `dnf` in Fedora and keep `yum` in RHEL

`which` is non-standard. Use builtin `command -v` instead