### PR TITLE
Install nodejs v10 in Fedora 31, not v12 by default

### DIFF
--- a/test/vm.install
+++ b/test/vm.install
@@ -15,7 +15,11 @@ if type firewall-cmd >/dev/null 2>&1; then
 fi
 
 # Install nodejs if it does not exist
-command -v node > /dev/null 2>&1 || $(command -v dnf || command -v yum) install -y nodejs
+if grep -isq fedora /etc/redhat-release; then
+    command -v node > /dev/null 2>&1 || dnf module install -y nodejs:10
+else
+    command -v node > /dev/null 2>&1 || $(command -v dnf || command -v yum) install -y nodejs
+fi
 
 # disable https in cockpit and use http instead
 printf "[WebService]\\nAllowUnencrypted=true\\n" > /etc/cockpit/cockpit.conf


### PR DESCRIPTION
The fibers (one of dependence of wdio_sync) does not work with nodejs v12 and Fedora 31 install nodejs v12 by default. Installing nodejs v10 works around this issue