### PR TITLE
test: Fix "View Blueprint Page image type should be tar" case failed on RHEL-7-8

### DIFF
--- a/components/ListView/ListItemImages.js
+++ b/components/ListView/ListItemImages.js
@@ -117,7 +117,7 @@ class ListItemImages extends React.Component {
                   <FormattedMessage
                     defaultMessage="Type {type}"
                     values={{
-                      type: <strong>{listItem.compose_type}</strong>
+                      type: <strong data-image-type={listItem.compose_type}>{listItem.compose_type}</strong>
                     }}
                   />
                 </div>

--- a/test/end-to-end/pages/ViewBlueprint.page.js
+++ b/test/end-to-end/pages/ViewBlueprint.page.js
@@ -268,7 +268,7 @@ class ViewBlueprintPage {
   }
 
   imageTypeLabel(type) {
-    const selector = `strong=${type}`;
+    const selector = `[data-image-type=${type}]`;
     browser.waitUntil(
       () => browser.isExisting(selector),
       timeout,


### PR DESCRIPTION
Fix failed case issue:
```
    1) View Blueprint Page image type should be tar:
    expected '' to equal 'tar'
```

The failed case is because the openssh-server dependencies on RHEL 7.8
have tar included. The selector 'strong=tar' will have two elements
matched, and the first matched element is the dependence one, not the
image type. But the tar is not one of dependencies of openssh-server on
Fedora or RHEL 8. So this issue cannot be found on those two test
scenarios.