### PR TITLE
Allow user to fix depsolve errors on Edit page

### DIFF
--- a/components/ListView/BlueprintContents.js
+++ b/components/ListView/BlueprintContents.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { defineMessages, injectIntl, intlShape, FormattedMessage } from "react-intl";
 import PropTypes from "prop-types";
-import { DataList } from "@patternfly/react-core";
+import { DataList, Alert } from "@patternfly/react-core";
 import { Tabs, Tab } from "patternfly-react";
 import ComponentsDataListItem from "./ComponentsDataListItem";
 import DependencyListView from "./DependencyListView";
@@ -47,6 +47,12 @@ const BlueprintContents = props => {
   } = props;
 
   const { formatMessage } = props.intl;
+  const alertAction =
+    pastLength > 0 ? (
+      <button className="pf-c-button pf-m-link" type="button" onClick={() => undo()}>
+        <FormattedMessage defaultMessage="Undo Last Change" />
+      </button>
+    ) : null;
 
   return (
     <div>
@@ -69,17 +75,16 @@ const BlueprintContents = props => {
               )) || (
                 <>
                   {Object.keys(errorState).length > 0 && (
-                    <EmptyState
+                    <Alert
                       title={formatMessage(messages.emptyStateErrorTitle)}
-                      message={formatMessage(messages.emptyStateErrorMessage)}
+                      isInline
+                      variant="danger"
+                      action={alertAction}
+                      className="pf-u-mt-md pf-u-mb-md"
                     >
+                      <p>{formatMessage(messages.emptyStateErrorMessage)}</p>
                       <p>{errorState.msg}</p>
-                      {pastLength > 0 && (
-                        <button className="btn btn-link btn-lg" type="button" onClick={() => undo()}>
-                          <FormattedMessage defaultMessage="Undo Last Change" />
-                        </button>
-                      )}
-                    </EmptyState>
+                    </Alert>
                   )}
                   <DataList
                     data-list="components"

--- a/components/ListView/BlueprintContents.js
+++ b/components/ListView/BlueprintContents.js
@@ -51,20 +51,7 @@ const BlueprintContents = props => {
   return (
     <div>
       {(fetchingState === true && <Loading />) ||
-        (Object.keys(errorState).length > 0 && (
-          <EmptyState
-            title={formatMessage(messages.emptyStateErrorTitle)}
-            message={formatMessage(messages.emptyStateErrorMessage)}
-          >
-            <p>{errorState.msg}</p>
-            {pastLength > 0 && (
-              <button className="btn btn-link btn-lg" type="button" onClick={() => undo()}>
-                <FormattedMessage defaultMessage="Undo Last Change" />
-              </button>
-            )}
-          </EmptyState>
-        )) ||
-        (components.length === 0 && filterValues.length === 0 && <div>{props.children}</div>) || (
+        ((components.length === 0 && filterValues.length === 0 && <div>{props.children}</div>) || (
           <Tabs id="blueprint-tabs">
             <Tab
               eventKey="selected-components"
@@ -80,22 +67,37 @@ const BlueprintContents = props => {
                   </button>
                 </EmptyState>
               )) || (
-                <DataList
-                  data-list="components"
-                  aria-label={formatMessage(messages.selectedTabTitle)}
-                  className="cc-m-nowrap-on-xl cc-components"
-                >
-                  {components.map(listItem => (
-                    <ComponentsDataListItem
-                      listItem={listItem}
-                      key={listItem.name}
-                      handleRemoveComponent={handleRemoveComponent}
-                      handleComponentDetails={handleComponentDetails}
-                      noEditComponent={noEditComponent}
-                      fetchDetails={fetchDetails}
-                    />
-                  ))}
-                </DataList>
+                <>
+                  {Object.keys(errorState).length > 0 && (
+                    <EmptyState
+                      title={formatMessage(messages.emptyStateErrorTitle)}
+                      message={formatMessage(messages.emptyStateErrorMessage)}
+                    >
+                      <p>{errorState.msg}</p>
+                      {pastLength > 0 && (
+                        <button className="btn btn-link btn-lg" type="button" onClick={() => undo()}>
+                          <FormattedMessage defaultMessage="Undo Last Change" />
+                        </button>
+                      )}
+                    </EmptyState>
+                  )}
+                  <DataList
+                    data-list="components"
+                    aria-label={formatMessage(messages.selectedTabTitle)}
+                    className="cc-m-nowrap-on-xl cc-components"
+                  >
+                    {components.map(listItem => (
+                      <ComponentsDataListItem
+                        listItem={listItem}
+                        key={listItem.name}
+                        handleRemoveComponent={handleRemoveComponent}
+                        handleComponentDetails={handleComponentDetails}
+                        noEditComponent={noEditComponent}
+                        fetchDetails={fetchDetails}
+                      />
+                    ))}
+                  </DataList>
+                </>
               )}
             </Tab>
             <Tab
@@ -124,7 +126,7 @@ const BlueprintContents = props => {
               )}
             </Tab>
           </Tabs>
-        )}
+        ))}
     </div>
   );
 };
@@ -160,7 +162,7 @@ BlueprintContents.defaultProps = {
   filterClearValues: function() {},
   filterValues: [],
   errorState: {},
-  fetchingState: false,
+  fetchingState: true,
   fetchDetails: function() {},
   children: React.createElement("div"),
   pastLength: 0,

--- a/components/ListView/BlueprintContents.js
+++ b/components/ListView/BlueprintContents.js
@@ -107,8 +107,13 @@ const BlueprintContents = props => {
             </Tab>
             <Tab
               eventKey="dependencies"
+              disabled={Object.keys(errorState).length > 0}
               title={
-                <LabelWithBadge title={formatMessage(messages.dependenciesTabTitle)} badge={dependencies.length} />
+                <LabelWithBadge
+                  title={formatMessage(messages.dependenciesTabTitle)}
+                  badge={dependencies.length}
+                  error={Object.keys(errorState).length > 0}
+                />
               }
             >
               {(dependencies.length === 0 && (

--- a/components/ListView/ComponentDetailsView.js
+++ b/components/ListView/ComponentDetailsView.js
@@ -75,6 +75,9 @@ class ComponentDetailsView extends React.Component {
         const selectedVersion = selectedComponents.find(selected => selected.name === component.name).version;
         const selectedBuild = component.builds.filter(obj => obj.version === selectedVersion)[0];
         index = component.builds.indexOf(selectedBuild);
+        if (index === -1) {
+          index = 0;
+        }
         this.setState({ selectedBuildIndex: index });
         this.setState({ savedVersion: selectedVersion });
         this.handleSelectedBuildDeps(index);

--- a/components/ListView/ComponentsDataListItem.js
+++ b/components/ListView/ComponentsDataListItem.js
@@ -86,13 +86,13 @@ class ComponentsDataListItem extends React.Component {
                 key="secondary"
                 className="cc-component__version pf-u-display-flex-on-xl pf-u-flex-direction-column"
               >
-                <FormattedMessage defaultMessage="Version" />` `<strong>{listItem.version}</strong>
+                <FormattedMessage defaultMessage="Version" /> <strong>{listItem.version}</strong>
               </DataListCell>,
               <DataListCell
                 key="tertiary"
                 className="cc-component__release pf-u-display-flex-on-xl pf-u-flex-direction-column"
               >
-                <FormattedMessage defaultMessage="Release" />` `<strong>{listItem.release}</strong>
+                <FormattedMessage defaultMessage="Release" /> <strong>{listItem.release}</strong>
               </DataListCell>
             ]}
           />

--- a/components/ListView/LabelWithBadge.js
+++ b/components/ListView/LabelWithBadge.js
@@ -5,19 +5,27 @@ export default function LabelWithBadge(props) {
   return (
     <span>
       {props.title}&nbsp;
-      <span className="badge" data-badge={props.title}>
-        {props.badge}
-      </span>
+      {(props.error && (
+        <span className="badge" data-badge={props.title}>
+          ?
+        </span>
+      )) || (
+        <span className="badge" data-badge={props.title}>
+          {props.badge}
+        </span>
+      )}
     </span>
   );
 }
 
 LabelWithBadge.propTypes = {
   title: PropTypes.string,
-  badge: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  badge: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  error: PropTypes.bool
 };
 
 LabelWithBadge.defaultProps = {
   title: "",
-  badge: ""
+  badge: "",
+  error: false
 };

--- a/core/reducers/blueprints.js
+++ b/core/reducers/blueprints.js
@@ -114,7 +114,8 @@ const blueprintList = (state = [], action) => {
                 components: action.payload.components,
                 packages: action.payload.packages,
                 modules: action.payload.modules,
-                localPendingChanges: action.payload.pendingChange
+                localPendingChanges: action.payload.pendingChange,
+                errorState: {}
               }),
               future: []
             });
@@ -130,7 +131,8 @@ const blueprintList = (state = [], action) => {
               present: Object.assign({}, blueprint.present, {
                 components: action.payload.blueprint.components,
                 packages: action.payload.blueprint.packages,
-                modules: action.payload.blueprint.modules
+                modules: action.payload.blueprint.modules,
+                errorState: action.payload.blueprint.errorState
               })
             });
           }

--- a/core/sagas/blueprints.js
+++ b/core/sagas/blueprints.js
@@ -168,9 +168,6 @@ function* reloadBlueprintContents(blueprintId) {
   try {
     const response = yield call(composer.depsolveBlueprint, blueprintId);
     const blueprintData = response.blueprints[0];
-    if (response.errors.length > 0) {
-      yield put(blueprintContentsFailure(response.errors[0], blueprintId));
-    }
     let components = [];
     if (blueprintData.blueprint.packages.length > 0 || blueprintData.blueprint.modules.length > 0) {
       components = yield call(generateComponents, blueprintData);

--- a/pages/blueprintEdit/index.js
+++ b/pages/blueprintEdit/index.js
@@ -239,7 +239,7 @@ class EditBlueprintPage extends React.Component {
     this.props.clearSelectedInput();
     const selectedComponents = this.props.blueprint.packages.concat(this.props.blueprint.modules);
     const oldVersion = selectedComponents.find(component => component.name === name).version;
-    const updatedPackage = {
+    const updatedComponent = {
       name: name,
       version: version
     };
@@ -259,10 +259,13 @@ class EditBlueprintPage extends React.Component {
     if (prevChange === undefined || pendingChange.componentOld !== pendingChange.componentNew) {
       pendingChanges = [pendingChange].concat(pendingChanges);
     }
-    const packages = this.props.blueprint.packages
-      .filter(item => item.name !== updatedPackage.name)
-      .concat(updatedPackage);
-    const modules = this.props.blueprint.modules;
+    let packages = this.props.blueprint.packages;
+    let modules = this.props.blueprint.modules;
+    if (modules.some(component => component.name === name)) {
+      modules = modules.filter(item => item.name !== updatedComponent.name).concat(updatedComponent);
+    } else {
+      packages = packages.filter(item => item.name !== updatedComponent.name).concat(updatedComponent);
+    }
     const components = this.props.blueprint.components.map(component => {
       if (component.name === name) {
         const componentData = Object.assign({}, component, {

--- a/pages/blueprintEdit/index.js
+++ b/pages/blueprintEdit/index.js
@@ -372,7 +372,7 @@ class EditBlueprintPage extends React.Component {
 
   render() {
     if (this.props.blueprint.id === undefined) {
-      return <div />;
+      return <Loading />;
     }
     const blueprintDisplayName = this.props.route.params.blueprint;
     const {
@@ -791,7 +791,7 @@ EditBlueprintPage.defaultProps = {
   redo: function() {},
   deleteHistory: function() {},
   blueprintContentsError: {},
-  blueprintContentsFetching: false
+  blueprintContentsFetching: true
 };
 
 const makeMapStateToProps = () => {


### PR DESCRIPTION
Before this update, if a blueprint had a package with a version that resulted in a depsolve failure, then an error message would display in the Edit page, and the only workaround for fixing the error is by editing the TOML file through the cli.

This update still displays the error message, but also includes the list of selected components so that the user can find the component that is mentioned in the error and resolve the issue by either removing the component or selecting a different version.

~Still to be included is the last statement in issue #718 (i.e. preventing the user from creating an image when an error exists).~ Going to defer this to a future PR.

Some ways to test this:
1. Add the package "soletta" to a blueprint. In this case, dependencies required by soletta are missing and will return an error. But the list of packages are still displayed. In this case, you will also see the Undo action display in the alert.
2. Edit the toml file of a blueprint to have bad version numbers for packages (or navigate to the Edit page for the atlas blueprint, which has old version numbers defined). 