### PR TITLE
Switch to osbuild-composer backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@
 
 **The web interface for Composer!**
 
-Composer generates custom images suitable for deploying systems or uploading to the cloud. It integrates into [Cockpit](https://cockpit-project.org/) as a frontend for [Lorax Composer](https://github.com/weldr/lorax/tree/lorax-composer).
+Composer generates custom images suitable for deploying systems or uploading to
+the cloud. It integrates into [Cockpit](https://cockpit-project.org/) as a
+frontend for [osbuild](https://github.com/osbuild).
 
 ## Making changes on Cockpit Composer
 
@@ -22,10 +24,10 @@ Cockpit Composer git repository checkout.
 On Fedora or Red Hat Enterprise Linux:
 
 * First install Cockpit on your local machine as described in: https://cockpit-project.org/running.html.
-* Next install and start lorax-composer:
+* Next install and start osbuild-composer:
 ```
-    $ sudo yum install lorax-composer
-    $ sudo systemctl start lorax-composer
+    $ sudo yum install osbuild-composer
+    $ sudo systemctl start osbuild-composer
 ```
 
 * Cockpit Composer uses Node.js during development. Node.js is not used at runtime. To make changes on Cockpit you'll want to install Node.js, NPM.

--- a/cockpit-composer.spec.in
+++ b/cockpit-composer.spec.in
@@ -11,11 +11,11 @@ BuildArch:      noarch
 BuildRequires:  libappstream-glib
 
 Requires:       cockpit
-Requires:       lorax-composer
+Requires:       osbuild-composer >= 4
 
 %description
 Composer generates custom images suitable for deploying systems or uploading to
-the cloud. It integrates into Cockpit as a frontend for Lorax Composer.
+the cloud. It integrates into Cockpit as a frontend for osbuild.
 
 %prep
 %setup -q -n cockpit-composer-%{version}

--- a/components/EmptyState/EmptyStateInactive.js
+++ b/components/EmptyState/EmptyStateInactive.js
@@ -57,14 +57,14 @@ class EmptyStateInactive extends React.Component {
 
   startService(e) {
     if (!e || e.button !== 0) return;
-    let argv;
+    let script;
     if (this.state.enableService) {
-      argv = ["systemctl", "enable", "--now", "osbuild-composer.socket"];
+      script = "systemctl enable --now osbuild-composer.socket && systemctl enable --now osbuild-worker@1";
     } else {
-      argv = ["systemctl", "start", "osbuild-composer.socket"];
+      script = "systemctl start osbuild-composer.socket && systemctl start osbuild-worker@1";
     }
     cockpit
-      .spawn(argv, { superuser: "require", err: "message" })
+      .script(script, { superuser: "require", err: "message" })
       .then(() => this.props.fetchingBlueprints())
       .catch(err => {
         this.setState({ enableServiceFailure: err.message });

--- a/components/EmptyState/EmptyStateInactive.js
+++ b/components/EmptyState/EmptyStateInactive.js
@@ -16,10 +16,10 @@ const messages = defineMessages({
     defaultMessage: "Troubleshoot"
   },
   errorInactiveCheckbox: {
-    defaultMessage: "Automatically start lorax-composer on boot"
+    defaultMessage: "Automatically start osbuild-composer on boot"
   },
   alertTitleEnableServiceFailure: {
-    defaultMessage: "The service lorax-composer was not started."
+    defaultMessage: "The service osbuild-composer was not started."
   },
   alertMessagePreface: {
     defaultMessage: "Message"
@@ -59,22 +59,22 @@ class EmptyStateInactive extends React.Component {
     if (!e || e.button !== 0) return;
     let argv;
     if (this.state.enableService) {
-      argv = ["systemctl", "enable", "--now", "lorax-composer.socket"];
+      argv = ["systemctl", "enable", "--now", "osbuild-composer.socket"];
     } else {
-      argv = ["systemctl", "start", "lorax-composer.socket"];
+      argv = ["systemctl", "start", "osbuild-composer.socket"];
     }
     cockpit
       .spawn(argv, { superuser: "require", err: "message" })
       .then(() => this.props.fetchingBlueprints())
       .catch(err => {
         this.setState({ enableServiceFailure: err.message });
-        console.error("Failed to start lorax-composer.socket:", JSON.stringify(err));
+        console.error("Failed to start osbuild-composer.socket:", JSON.stringify(err));
       });
   }
 
   goToServicePage(e) {
     if (!e || e.button !== 0) return;
-    cockpit.jump("/system/services#/lorax-composer.service");
+    cockpit.jump("/system/services#/osbuild-composer.service");
   }
 
   render() {

--- a/test/end-to-end/pages/blueprints.page.js
+++ b/test/end-to-end/pages/blueprints.page.js
@@ -8,9 +8,10 @@ class BlueprintsPage {
     return ".pf-c-data-list .pf-c-data-list__item";
   }
 
+  // if the create blueprint button is enabled the page has loaded
   loading() {
-    $(this.blueprintListView).waitForExist(timeout);
-    browser.waitUntil(() => $$(this.blueprintListView).length >= 3, timeout, "Loading Blueprints page failed");
+    const createBlueprintButtonSelector = "#cmpsr-btn-crt-blueprint";
+    browser.waitUntil(() => browser.isEnabled(createBlueprintButtonSelector), timeout, "Loading Blueprints page failed");
   }
 
   filterLoading() {

--- a/test/end-to-end/specs/api.test.js
+++ b/test/end-to-end/specs/api.test.js
@@ -33,8 +33,6 @@ describe("weldr api sanity test", function() {
       console.log('Failed to access API - "/api/v0/blueprints/list" with error: ', result.data);
     }
     expect(result.success).to.be.true;
-    // there're 3 blueprints included in composer by default
-    expect(JSON.parse(result.data).total).to.equal(3);
     expect(result.latency)
       .to.match(/^\d*(\.?\d+|\d*)$/)
       .and.be.below(acceptable);

--- a/test/end-to-end/specs/api.test.js
+++ b/test/end-to-end/specs/api.test.js
@@ -6,7 +6,7 @@ const blueprintsPage = require("../pages/blueprints.page");
 // but on slow/loaded nested-VM OSCI infrastructure this often takes much longer
 const acceptable = 10000;
 
-describe("lorax-composer api sanity test", function() {
+describe("weldr api sanity test", function() {
   before(function() {
     commands.login();
     commands.startLoraxIfItDoesNotStart();
@@ -15,10 +15,10 @@ describe("lorax-composer api sanity test", function() {
     blueprintsPage.loading();
   });
 
-  it("lorax-composer.socket should be enabled", function() {
+  it("weldr api socket should be enabled", function() {
     const status = browser.executeAsync(function(done) {
       cockpit
-        .script("systemctl is-enabled lorax-composer.socket", { superuser: "require", err: "message" })
+        .script("systemctl is-enabled osbuild-composer.socket", { superuser: "require", err: "message" })
         .then(data => done(data));
     });
     expect(status.value.trim()).to.equal("enabled");

--- a/test/end-to-end/specs/blueprints.test.js
+++ b/test/end-to-end/specs/blueprints.test.js
@@ -97,8 +97,8 @@ describe("Blueprints Page", function() {
       blueprintsPage.clearAllFiltersLink.click();
       blueprintsPage.waitForActiveFiltersNotExist();
       blueprintsPage.loading();
-      // one new added blueprints + three default blueprints
-      expect($$(blueprintsPage.blueprintListView)).to.have.lengthOf.above(1);
+      // one new added blueprint
+      expect($$(blueprintsPage.blueprintListView)).to.have.lengthOf.above(0);
     });
 
     it("should have correct filter content label and clear filter result by clicking X button", function() {
@@ -106,8 +106,8 @@ describe("Blueprints Page", function() {
       blueprintsPage.filterContentLabelCloseButton.click();
       blueprintsPage.waitForActiveFiltersNotExist();
       blueprintsPage.loading();
-      // one new added blueprints + three default blueprints
-      expect($$(blueprintsPage.blueprintListView)).to.have.lengthOf.above(1);
+      // one new added blueprint
+      expect($$(blueprintsPage.blueprintListView)).to.have.lengthOf.above(0);
     });
   });
 });

--- a/test/vm.install
+++ b/test/vm.install
@@ -3,11 +3,6 @@
 # The application RPM will be installed separately
 set -eux
 
-# Update lorax-composer using the updates-testing repository
-if grep -isq fedora /etc/redhat-release && grep -isq firefox /tmp/BROWSER; then
-    dnf install -y lorax-composer --enablerepo=updates-testing
-fi
-
 # Allow cockpit port (9090) in INPUT chain
 # Do not reload firewall rule during image generation
 if type firewall-cmd >/dev/null 2>&1; then
@@ -28,12 +23,9 @@ printf "[WebService]\\nAllowUnencrypted=true\\n" > /etc/cockpit/cockpit.conf
 # Do not start it during image generation
 systemctl enable cockpit.socket
 
-# Start lorax-composer to init its db, but do not "enable" it
+# Start osbuild-composer to init its db, but do not "enable" it
 # Tests expect the service to not run, it checks the "start service" button
-systemctl start lorax-composer
+systemctl start osbuild-composer
 
-# wait for lorax-composer initialization before running test
-until curl --unix-socket /run/weldr/api.socket \
-    http://localhost:4000/api/status | grep '"db_supported": *true'; do
-sleep 1;
-done;
+# TODO temporary until osbuild-composer depends on one worker
+systemctl start osbuild-worker@1


### PR DESCRIPTION
osbuild-composer is a drop-in replacement for lorax-composer, providing
the same API:

    https://github.com/osbuild/osbuild-composer

Switch the dependency, documentation, and the name of the service for
the "Start Service" page.