### PR TITLE
test: Add timeline test report

### DIFF
--- a/test/end-to-end/package.json
+++ b/test/end-to-end/package.json
@@ -12,6 +12,7 @@
     "del": "^5.1.0",
     "faker": "^4.1.0",
     "path": "^0.12.7",
+    "wdio-timeline-reporter": "^5.1.2",
     "webdriverio": "^5.16.6"
   },
   "devDependencies": {

--- a/test/end-to-end/wdio.conf.js
+++ b/test/end-to-end/wdio.conf.js
@@ -2,6 +2,7 @@ const path = require("path");
 const del = require("del");
 const fs = require("fs");
 const crypto = require("crypto");
+const { TimelineService } = require('wdio-timeline-reporter/timeline-service');
 // import commands to add them as browser and element scope commands
 const commands = require("./utils/commands");
 
@@ -130,7 +131,7 @@ exports.config = {
   // Services take over a specific job you don't want to take care of. They enhance
   // your test setup with almost no effort. Unlike plugins, they don't add new
   // commands. Instead, they hook themselves up into the test process.
-  // services: [],
+  services: [[TimelineService]],
   //
   // Framework you want to run your specs with.
   // The following are supported: Mocha, Jasmine, and Cucumber
@@ -155,6 +156,20 @@ exports.config = {
         outputFileFormat: function() {
           return "xunit_report.xml";
         }
+      }
+    ],
+    [
+      "timeline",
+      {
+        outputDir: reportDir,
+        fileName: "timeline-reporter.html",
+        embedImages: true,
+        images: {
+          quality: 80,
+          resize: false,
+          reductionRatio: 2
+        },
+        screenshotStrategy: "before:click"
       }
     ]
   ],


### PR DESCRIPTION
Timeline report aggregates all the typical information you will need into one report. Run tests and have a nice timeline of events you can look back at to further verify everything looks ok.
Report example:
[Edge](https://209.132.184.41:8493/logs/pull-848-20191213-065656-c6b2d24a-weldr-cockpit-composer--fedora-31-edge/wdio_report/timeline-reporter.html)
[Firefox](https://209.132.184.41:8493/logs/pull-848-20191213-065656-c6b2d24a-weldr-cockpit-composer--rhel-7-8-firefox/wdio_report/timeline-reporter.html)
[Chrome](https://209.132.184.41:8493/logs/pull-848-20191213-065656-c6b2d24a-weldr-cockpit-composer--rhel-8-1-chrome/wdio_report/timeline-reporter.html)