### PR TITLE
Migrates Images list view to the PF4 data list

### DIFF
--- a/components/ListView/ImagesDataList.js
+++ b/components/ListView/ImagesDataList.js
@@ -6,6 +6,7 @@ const ImagesDataList = props => (
   <DataList
     aria-label={props.ariaLabel}
     className="cc-c-tree-view"
+    data-list="images"
   >
     {props.children}
   </DataList>

--- a/components/ListView/ImagesDataList.js
+++ b/components/ListView/ImagesDataList.js
@@ -1,0 +1,24 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { DataList } from "@patternfly/react-core";
+
+const ImagesDataList = props => (
+  <DataList
+    aria-label={props.ariaLabel}
+    className="cc-c-tree-view"
+  >
+    {props.children}
+  </DataList>
+);
+
+ImagesDataList.propTypes = {
+  ariaLabel: PropTypes.string,
+  children: PropTypes.node
+};
+
+ImagesDataList.defaultProps = {
+  ariaLabel: "",
+  children: React.createElement("div")
+};
+
+export default ImagesDataList;

--- a/components/ListView/ListItemImages.js
+++ b/components/ListView/ListItemImages.js
@@ -1,7 +1,17 @@
 import React from "react";
-import { FormattedMessage } from "react-intl";
+import { FormattedMessage, defineMessages, injectIntl, intlShape } from "react-intl";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
+import {
+  Button,
+  DataListItem,
+  DataListItemRow,
+  DataListCell,
+  DataListToggle,
+  DataListContent,
+  DataListItemCells
+} from "@patternfly/react-core";
+import { BuilderImageIcon } from "@patternfly/react-icons";
 import { deletingCompose, cancellingCompose } from "../../core/actions/composes";
 import {
   setModalStopBuildVisible,
@@ -9,7 +19,57 @@ import {
   setModalDeleteImageVisible,
   setModalDeleteImageState
 } from "../../core/actions/modals";
+import Logs from "../Logs/Logs";
 import * as composer from "../../core/composer";
+import ImagesDataList from "./ImagesDataList";
+import ListItemUploads from "./ListItemUploads";
+
+const messages = defineMessages({
+  imageType: {
+    defaultMessage: "Type",
+    description: "A label for the type of image file was created"
+  },
+  imageCreated: {
+    defaultMessage: "Created",
+    description: "A label for the date that an image file was created"
+  },
+  imageSize: {
+    defaultMessage: "Size",
+    description: "A label for the size of an image file"
+  },
+  imageUploads: {
+    defaultMessage: "Image uploads",
+    description: "A label for the section that lists the upload actions initiated by the user"
+  },
+  imageActions: {
+    defaultMessage: "Actions",
+    description: "A label for the menu that displays the actions available"
+  },
+  imageLogs: {
+    defaultMessage: "Logs",
+    description: "Log content that gets generated as part of the image creation process"
+  },
+  imageStatusWaiting: {
+    defaultMessage: "Image build pending",
+    description: "Image build status when process is waiting"
+  },
+  imageStatusRunning: {
+    defaultMessage: "Image build in progress",
+    description: "Image build status when process is in progress"
+  },
+  imageStatusFinished: {
+    defaultMessage: "Image build complete",
+    description: "Image build status when process is finished"
+  },
+  imageStatusFailed: {
+    defaultMessage: "Image build failed",
+    description: "Image build status when process failed"
+  },
+  imageStatusStopping: {
+    defaultMessage: "Stopping",
+    description: "Image build status when user selected to end the process"
+  }
+});
 
 class ListItemImages extends React.Component {
   constructor() {
@@ -23,17 +83,23 @@ class ListItemImages extends React.Component {
   }
 
   // maps to Remove button for FAILED
-  handleDelete() {
+  handleDelete(e) {
+    e.preventDefault();
+    e.stopPropagation();
     this.props.deletingCompose(this.props.listItem.id);
   }
 
   // maps to Stop button for WAITING
-  handleCancel() {
+  handleCancel(e) {
+    e.preventDefault();
+    e.stopPropagation();
     this.props.cancellingCompose(this.props.listItem.id);
   }
 
   // maps to Stop button for RUNNING
-  handleShowModalStop() {
+  handleShowModalStop(e) {
+    e.preventDefault();
+    e.stopPropagation();
     this.props.setModalStopBuildState(this.props.listItem.id, this.props.blueprint);
     this.props.setModalStopBuildVisible(true);
   }
@@ -47,6 +113,7 @@ class ListItemImages extends React.Component {
   }
 
   handleLogsShow() {
+    this.setState({ uploadsExpanded: false });
     this.setState(prevState => ({ logsExpanded: !prevState.logsExpanded, fetchingLogs: !prevState.logsExpanded }));
     composer.getComposeLog(this.props.listItem.id).then(
       logs => {
@@ -60,154 +127,235 @@ class ListItemImages extends React.Component {
       }
     );
   }
+  // consider removing
+  handleUploadsShow() {
+    this.setState({ logsExpanded: false });
+    this.setState(prevState => ({ uploadsExpanded: !prevState.uploadsExpanded }));
+  }
 
   render() {
     const { listItem } = this.props;
+    const { formatMessage } = this.props.intl;
     const timestamp = new Date(listItem.job_created * 1000);
     const formattedTime = timestamp.toDateString();
-    const moreButton = (
-      <button className="btn btn-link" onClick={this.handleLogsShow} type="button">
-        {this.state.logsExpanded && <FormattedMessage defaultMessage="Hide logs" />}
-        {!this.state.logsExpanded && <FormattedMessage defaultMessage="Show logs" />}
-      </button>
+    let actions;
+    switch (listItem.queue_status) {
+      case "FINISHED":
+        actions = (
+          <>
+            <li>
+              <a href={this.props.downloadUrl} role="button" download>
+                <FormattedMessage defaultMessage="Download" />
+              </a>
+            </li>
+            <li key="delete">
+              <a href="#" role="button" onClick={e => this.handleShowModalDeleteImage(e)}>
+                <FormattedMessage defaultMessage="Delete" />
+              </a>
+            </li>
+          </>
+        );
+        break;
+      case "RUNNING":
+        actions = (
+          <>
+            <li>
+              <a href="#" role="button" onClick={e => this.handleShowModalStop(e)}>
+                <FormattedMessage defaultMessage="Stop" />
+              </a>
+            </li>
+          </>
+        );
+        break;
+      case "WAITING":
+        actions = (
+          <>
+            <li>
+              <a href="#" role="button" onClick={e => this.handleCancel(e)}>
+                <FormattedMessage defaultMessage="Stop" />
+              </a>
+            </li>
+          </>
+        );
+        break;
+      case "FAILED":
+        actions = (
+          <>
+            <li>
+              <a href="#" role="button" onClick={e => this.handleDelete(e)}>
+                <FormattedMessage defaultMessage="Remove" />
+              </a>
+            </li>
+          </>
+        );
+        break;
+      default:
+        actions = undefined;
+        break;
+    }
+    const noLogs = listItem.queue_status === "WAITING" || listItem.queue_status === "STOPPING";
+    const logsButton = (
+      <div
+        aria-hidden={noLogs}
+        className={`pf-c-data-list__item-action ${noLogs ? "cc-u-not-visible" : ""}`}
+      >
+        <Button
+          variant={`${this.state.logsExpanded ? "primary" : "secondary"}`}
+          aria-expanded={this.state.logsExpanded}
+          aria-controls={`${listItem.id}-logs`}
+          onClick={this.handleLogsShow}
+        >
+          {formatMessage(messages.imageLogs)}
+        </Button>
+      </div>
     );
+    let uploadsToggle;
+    if (listItem.uploads !== undefined) {
+      uploadsToggle = (
+        <DataListToggle
+            onClick={this.handleUploadsShow}
+            isExpanded={this.state.uploadsExpanded}
+            id="uploads-toggle"
+            aria-label={`${formatMessage(messages.imageUploads)} ${this.props.blueprint}-${listItem.version}-${listItem.compose_type}`}
+            aria-controls={`${listItem.id}-uploads`}
+            // ^ need to fix this attribute value
+            aria-hidden={!listItem.uploads.length > 0}
+            className={`${!listItem.uploads.length > 0 ? "cc-u-not-visible" : ""}`}
+          />
+      );
+    }
+    const composeStatus = () => {
+      switch (listItem.queue_status) {
+        case "WAITING":
+          return (
+            <div className="cc-c-status">
+              <div className="cc-c-status__icon">
+                <span className="pficon pficon-pending" aria-hidden="true" />
+              </div>
+              {formatMessage(messages.imageStatusWaiting)}
+            </div>
+          );
+        case "RUNNING":
+          return (
+            <div className="cc-c-status">
+              <div className="cc-c-status__icon">
+                <div className="spinner spinner-xs" />
+              </div>
+              {formatMessage(messages.imageStatusRunning)}
+            </div>
+          );
+        case "FINISHED":
+          return (
+            <div className="cc-c-status">
+              <div className="cc-c-status__icon">
+                <span className="pficon pficon-ok" aria-hidden="true" />
+              </div>
+              {formatMessage(messages.imageStatusFinished)}
+            </div>
+          );
+        case "FAILED":
+          return (
+            <div className="cc-c-status">
+              <div className="cc-c-status__icon">
+                <span className="pficon pficon-error-circle-o" aria-hidden="true" />
+              </div>
+              {formatMessage(messages.imageStatusFailed)}
+            </div>
+          );
+        case "STOPPING":
+          return (
+            <div className="cc-c-status">
+              <em className="text-muted cc-m-full-width">
+                {formatMessage(messages.imageStatusStopping)}
+              </em>
+            </div>
+          );
+        default:
+          return <></>;
+      }
+    };
     let logsSection;
     if (this.state.logsExpanded) {
-      if (this.state.fetchingLogs) {
-        logsSection = (
-          <div>
-            <div className="spinner spinner-sm pull-left" aria-hidden="true" />
-            <FormattedMessage defaultMessage="Loading log messages" />
-          </div>
-        );
-      } else logsSection = <pre>{this.state.logsContent}</pre>;
+      logsSection = <Logs logContent={this.state.logsContent} fetchingLog={this.state.fetchingLogs} />;
     }
+    let uploadsSection;
+    if (this.state.uploadsExpanded) {
+      uploadsSection = (
+        <ImagesDataList ariaLabel={formatMessage(messages.imageUploads)}>
+          {listItem.uploads.map(upload => (
+            <ListItemUploads upload={upload} key={upload.uuid} />
+          ))}
+        </ImagesDataList>
+      );
+    }
+    const size = Math.round(listItem.image_size / 10000000) / 100;
 
     return (
-      <div className="list-pf-item">
-        <div className="list-pf-container image-container">
-          <div className="list-pf-content list-pf-content-flex">
-            <div className="list-pf-left">
-              <span className="pficon pficon-builder-image list-pf-icon-small" aria-hidden="true" />
-            </div>
-            <div className="list-pf-content-wrapper">
-              <div className="list-pf-main-content">
-                <div className="list-pf-title text-overflow-pf">
-                  {this.props.blueprint}-ver{listItem.version}-{listItem.compose_type}
-                </div>
-                <div className="list-pf-description">
-                  <FormattedMessage
-                    defaultMessage="Based on Version {version}"
-                    values={{
-                      version: listItem.version
-                    }}
-                  />
-                </div>
-              </div>
-              <div className="list-pf-additional-content">
-                <div className="list-view-pf-additional-info-item list-view-pf-additional-info-item-stacked i18n">
-                  <FormattedMessage
-                    defaultMessage="Date Created {date}"
-                    values={{
-                      date: <strong>{formattedTime}</strong>
-                    }}
-                  />
-                </div>
-                <div className="list-view-pf-additional-info-item list-view-pf-additional-info-item-stacked i18n">
-                  <FormattedMessage
-                    defaultMessage="Type {type}"
-                    values={{
-                      type: <strong data-image-type={listItem.compose_type}>{listItem.compose_type}</strong>
-                    }}
-                  />
-                </div>
-              </div>
-            </div>
-            {listItem.queue_status === "WAITING" && (
-              <div className="list-view-pf-additional-info-item cmpsr-images__status">
-                <span className="pficon pficon-pending" aria-hidden="true" />
-                <FormattedMessage defaultMessage="Pending" />
-              </div>
-            )}{" "}
-            {listItem.queue_status === "RUNNING" && (
-              <div className="list-view-pf-additional-info-item cmpsr-images__status">
-                <span className="pficon pficon-in-progress" aria-hidden="true" />
-                <FormattedMessage defaultMessage="In Progress" />
-                {moreButton}
-              </div>
-            )}{" "}
-            {listItem.queue_status === "FINISHED" && (
-              <div className="list-view-pf-additional-info-item cmpsr-images__status">
-                <span className="pficon pficon-ok" aria-hidden="true" />
-                <FormattedMessage defaultMessage="Complete" />
-                {moreButton}
-              </div>
-            )}{" "}
-            {listItem.queue_status === "FAILED" && (
-              <div className="list-view-pf-additional-info-item cmpsr-images__status">
-                <span className="pficon pficon-error-circle-o" aria-hidden="true" />
-                <FormattedMessage defaultMessage="Failed" />
-                {moreButton}
-              </div>
-            )}
-            {listItem.queue_status === "FINISHED" && (
-              <div className="list-pf-actions">
-                <a className="btn btn-default" role="button" download href={this.props.downloadUrl}>
-                  <FormattedMessage defaultMessage="Download" />
-                </a>
-                <div className="dropdown pull-right dropdown-kebab-pf">
-                  <button
-                    className="btn btn-link dropdown-toggle"
-                    type="button"
-                    id="dropdownKebabRight"
-                    data-toggle="dropdown"
-                    aria-haspopup="true"
-                    aria-expanded="true"
-                  >
-                    <span className="fa fa-ellipsis-v" />
-                  </button>
-                  <ul className="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownKebabRight">
-                    <li>
-                      <a href="#" onClick={e => this.handleShowModalDeleteImage(e)}>
-                        <FormattedMessage defaultMessage="Delete" />
-                      </a>
-                    </li>
-                  </ul>
-                </div>
-              </div>
-            )}{" "}
-            {listItem.queue_status === "WAITING" && (
-              <div className="list-pf-actions">
-                <button type="button" className="btn btn-default" onClick={this.handleCancel}>
-                  <FormattedMessage defaultMessage="Stop" />
-                </button>
-              </div>
-            )}{" "}
-            {listItem.queue_status === "RUNNING" && (
-              <div className="list-pf-actions">
-                <button type="button" className="btn btn-default" onClick={this.handleShowModalStop}>
-                  <FormattedMessage defaultMessage="Stop" />
-                </button>
-              </div>
-            )}{" "}
-            {listItem.queue_status === "STOPPING" && (
-              <div className="list-pf-actions">
-                <em className="text-muted">
-                  <FormattedMessage defaultMessage="Stopping" />
-                </em>
-              </div>
-            )}{" "}
-            {listItem.queue_status === "FAILED" && (
-              <div className="list-pf-actions">
-                <button type="button" className="btn btn-default" onClick={this.handleDelete}>
-                  <FormattedMessage defaultMessage="Remove" />
-                </button>
-              </div>
-            )}
+      <DataListItem aria-labelledby={`${listItem.id}-compose-name`} isExpanded={this.state.uploadsExpanded}>
+        <DataListItemRow className={`${this.state.logsExpanded ? "cc-m-sticky" : ""}`}>
+          {uploadsToggle}
+          <div className="cc-c-data-list__item-icon">
+            <BuilderImageIcon />
           </div>
-        </div>
-        {logsSection}
-      </div>
+          <DataListItemCells
+            className="cc-m-stacked cc-m-split-on-lg"
+            dataListCells={[
+              <DataListCell key="primary" className="pf-l-flex pf-m-column pf-m-space-items-xs">
+                <div className="pf-l-flex__item">
+                  <strong id={`${listItem.id}-compose-name`}>
+                    {this.props.blueprint}-{listItem.version}-{listItem.compose_type}
+                  </strong>
+                </div>
+                <div className="pf-l-flex__item">
+                  <span>{formatMessage(messages.imageType)}</span> <strong>{listItem.compose_type}</strong>
+                </div>
+                <div className="pf-l-flex__item">
+                  <span>{formatMessage(messages.imageCreated)}</span> <strong>{formattedTime}</strong>
+                </div>
+                {listItem.queue_status === "FINISHED" && (
+                  <div className="pf-l-flex__item">
+                  <span>{formatMessage(messages.imageSize)}</span> <strong>{size} GB</strong>
+                </div>
+                )}
+              </DataListCell>,
+              <DataListCell key="status">{composeStatus()}</DataListCell>
+            ]}
+          />
+          <div
+            className={`pf-c-data-list__item-action ${actions === undefined ? "cc-u-not-visible" : ""}`}
+            aria-hidden={actions === undefined}
+          >
+            <div className="dropdown pull-right dropdown-kebab-pf">
+              <button
+                aria-label={formatMessage(messages.imageActions)}
+                className="btn btn-link dropdown-toggle"
+                type="button"
+                id={`${listItem.id}-actions`}
+                data-toggle="dropdown"
+                aria-haspopup="true"
+                aria-expanded="false"
+              >
+                <span className="fa fa-ellipsis-v" />
+              </button>
+              <ul className="dropdown-menu dropdown-menu-right" aria-labelledby={`${listItem.id}-actions`}>
+                {actions}
+              </ul>
+            </div>
+          </div>
+          {logsButton}
+        </DataListItemRow>
+        <DataListContent aria-label={formatMessage(messages.imageUploads)} id={`${listItem.id}-uploads`} isHidden={!this.state.uploadsExpanded} noPadding>
+          {uploadsSection}
+        </DataListContent>
+        <DataListContent
+          aria-label={formatMessage(messages.imageLogs)}
+          id={`${listItem.id}-logs`}
+          isHidden={!this.state.logsExpanded}
+          noPadding
+        >
+          {logsSection}
+        </DataListContent>
+      </DataListItem>
     );
   }
 }
@@ -231,7 +379,8 @@ ListItemImages.propTypes = {
   setModalStopBuildVisible: PropTypes.func,
   setModalDeleteImageState: PropTypes.func,
   setModalDeleteImageVisible: PropTypes.func,
-  downloadUrl: PropTypes.string
+  downloadUrl: PropTypes.string,
+  intl: intlShape.isRequired
 };
 
 ListItemImages.defaultProps = {
@@ -267,4 +416,4 @@ const mapDispatchToProps = dispatch => ({
   }
 });
 
-export default connect(null, mapDispatchToProps)(ListItemImages);
+export default connect(null, mapDispatchToProps)(injectIntl(ListItemImages));

--- a/components/ListView/ListItemImages.js
+++ b/components/ListView/ListItemImages.js
@@ -144,12 +144,12 @@ class ListItemImages extends React.Component {
         actions = (
           <>
             <li>
-              <a href={this.props.downloadUrl} role="button" download>
+              <a href={this.props.downloadUrl} role="button" data-download>
                 <FormattedMessage defaultMessage="Download" />
               </a>
             </li>
             <li key="delete">
-              <a href="#" role="button" onClick={e => this.handleShowModalDeleteImage(e)}>
+              <a href="#" role="button" onClick={e => this.handleShowModalDeleteImage(e)} data-delete>
                 <FormattedMessage defaultMessage="Delete" />
               </a>
             </li>
@@ -250,7 +250,7 @@ class ListItemImages extends React.Component {
               <div className="cc-c-status__icon">
                 <span className="pficon pficon-ok" aria-hidden="true" />
               </div>
-              {formatMessage(messages.imageStatusFinished)}
+              <span data-status>{formatMessage(messages.imageStatusFinished)}</span>
             </div>
           );
         case "FAILED":
@@ -291,7 +291,11 @@ class ListItemImages extends React.Component {
     const size = Math.round(listItem.image_size / 10000000) / 100;
 
     return (
-      <DataListItem aria-labelledby={`${listItem.id}-compose-name`} isExpanded={this.state.uploadsExpanded}>
+      <DataListItem 
+        aria-labelledby={`${listItem.id}-compose-name`}
+        isExpanded={this.state.uploadsExpanded}
+        data-image={`${this.props.blueprint}-${listItem.version}-${listItem.compose_type}`}
+      >
         <DataListItemRow className={`${this.state.logsExpanded ? "cc-m-sticky" : ""}`}>
           {uploadsToggle}
           <div className="cc-c-data-list__item-icon">
@@ -302,12 +306,13 @@ class ListItemImages extends React.Component {
             dataListCells={[
               <DataListCell key="primary" className="pf-l-flex pf-m-column pf-m-space-items-xs">
                 <div className="pf-l-flex__item">
-                  <strong id={`${listItem.id}-compose-name`}>
+                  <strong id={`${listItem.id}-compose-name`} data-image-name>
                     {this.props.blueprint}-{listItem.version}-{listItem.compose_type}
                   </strong>
                 </div>
                 <div className="pf-l-flex__item">
-                  <span>{formatMessage(messages.imageType)}</span> <strong>{listItem.compose_type}</strong>
+                  <span>{formatMessage(messages.imageType)} </span>
+                  <strong data-image-type={listItem.compose_type}>{listItem.compose_type}</strong>
                 </div>
                 <div className="pf-l-flex__item">
                   <span>{formatMessage(messages.imageCreated)}</span> <strong>{formattedTime}</strong>
@@ -370,7 +375,8 @@ ListItemImages.propTypes = {
     job_finished: PropTypes.number,
     job_started: PropTypes.number,
     queue_status: PropTypes.string,
-    version: PropTypes.string
+    version: PropTypes.string,
+    uploads: PropTypes.arrayOf(PropTypes.object)
   }),
   blueprint: PropTypes.string,
   deletingCompose: PropTypes.func,

--- a/components/ListView/ListItemUploads.js
+++ b/components/ListView/ListItemUploads.js
@@ -1,0 +1,185 @@
+import React from "react";
+import { defineMessages, injectIntl, intlShape } from "react-intl";
+import PropTypes from "prop-types";
+import {
+  Button,
+  DataListItem,
+  DataListItemRow,
+  DataListCell,
+  DataListItemCells
+} from "@patternfly/react-core";
+import { CaretDownIcon, ServiceIcon } from "@patternfly/react-icons";
+
+const messages = defineMessages({
+  imageName: {
+    defaultMessage: "Image name",
+    description: "The name given by the user for an image"
+  },
+  uploadType: {
+    defaultMessage: "Upload type",
+    description: "A label for the service to which an image was uploaded"
+  },
+  timeStarted: {
+    defaultMessage: "Started",
+    description: "A label for the date that an image upload was started"
+  },
+  uploadActions: {
+    defaultMessage: "Actions",
+    description: "A label for the menu that displays the actions available"
+  },
+  uploadLogs: {
+    defaultMessage: "Logs",
+    description: "Log content that gets generated as part of the upload process"
+  },
+  uploadStatusWaiting: {
+    defaultMessage: "Upload pending",
+    description: "Upload status when process is waiting"
+  },
+  uploadStatusRunning: {
+    defaultMessage: "Upload in progress",
+    description: "Upload status when process is in progress"
+  },
+  uploadStatusFinished: {
+    defaultMessage: "Upload complete",
+    description: "Upload status when process is finished"
+  },
+  uploadStatusFailed: {
+    defaultMessage: "Upload failed",
+    description: "Upload status when process failed"
+  }
+});
+
+class ListItemUploads extends React.PureComponent {
+  constructor(props) {
+    super(props);
+  }
+
+  render() {
+    const upload = this.props.upload;
+    const { formatMessage } = this.props.intl;
+    const timestamp = new Date(upload.creation_time * 1000);
+    const formattedTime = timestamp.toDateString();
+    const logsButton = (
+      <Button
+        variant="secondary"
+      >
+        {formatMessage(messages.uploadLogs)}
+      </Button>
+    );
+    const uploadStatus = () => {
+      switch (upload.status) {
+        case "WAITING":
+          return (
+            <div className="cc-c-status">
+              <div className="cc-c-status__icon">
+                <span className="pficon pficon-pending" aria-hidden="true" />
+              </div>
+              {formatMessage(messages.uploadStatusWaiting)}
+            </div>
+          );
+        case "RUNNING":
+          return (
+            <div className="cc-c-status">
+              <div className="cc-c-status__icon">
+                <div className="spinner spinner-xs" />
+              </div>
+              {formatMessage(messages.uploadStatusRunning)}
+            </div>
+          );
+        case "FINISHED":
+          return (
+            <div className="cc-c-status">
+              <div className="cc-c-status__icon">
+                <span className="pficon pficon-ok" aria-hidden="true" />
+              </div>
+              {formatMessage(messages.uploadStatusFinished)}
+            </div>
+          );
+        case "FAILED":
+          return (
+            <div className="cc-c-status">
+              <div className="cc-c-status__icon">
+                <span className="pficon pficon-error-circle-o" aria-hidden="true" />
+              </div>
+              {formatMessage(messages.uploadStatusFailed)}
+            </div>
+          );
+        default:
+          return <></>;
+      }
+    };
+
+    return (
+      <DataListItem aria-labelledby={`${upload.uuid}-type ${upload.uuid}-name`}>
+        <DataListItemRow>
+          <div className="pf-c-data-list__item-control cc-u-not-visible">
+            <div className="pf-c-data-list__toggle">
+              <Button variant="plain" aria-hidden="true">
+                <CaretDownIcon />
+              </Button>
+            </div>
+          </div>
+          <div className="cc-c-data-list__item-icon">
+            <ServiceIcon />
+          </div>
+          <DataListItemCells
+            className="cc-m-stacked cc-m-split-on-lg"
+            dataListCells={[
+              <DataListCell key="primary" className="pf-l-flex pf-m-column pf-m-space-items-xs">
+                {upload.image_name && upload.image_name !== "" && (
+                  <div className="pf-l-flex__item">
+                  <span>{formatMessage(messages.imageName)}</span> <strong id={`${upload.uuid}-name`}>{upload.image_name}</strong>
+                  </div>
+                )}
+                <div className="pf-l-flex__item">
+                  <span>{formatMessage(messages.uploadType)}</span> <strong id={`${upload.uuid}-type`}>{upload.provider_name}</strong>
+                </div>
+                <div className="pf-l-flex__item">
+                  <span>{formatMessage(messages.timeStarted)}</span> <strong>{formattedTime}</strong>
+                </div>
+              </DataListCell>,
+              <DataListCell key="status">{uploadStatus()}</DataListCell>
+            ]}
+          />
+          <div
+            className="pf-c-data-list__item-action cc-u-not-visible"
+            aria-hidden="true"
+          >
+            <div className="dropdown pull-right dropdown-kebab-pf">
+              <button
+                aria-label={formatMessage(messages.uploadActions)}
+                className="btn btn-link dropdown-toggle"
+                type="button"
+                id={`${upload.uuid}-actions`}
+              >
+                <span className="fa fa-ellipsis-v" />
+              </button>
+            </div>
+          </div>
+          <div
+            aria-hidden="true"
+            className="pf-c-data-list__item-action cc-u-not-visible"
+          >
+            {logsButton}
+          </div>
+        </DataListItemRow>
+      </DataListItem>
+    );
+  }
+}
+ListItemUploads.propTypes = {
+  upload: PropTypes.shape({
+    creation_time: PropTypes.number,
+    image_name: PropTypes.string,
+    provider_name: PropTypes.string,
+    status: PropTypes.string,
+    uuid: PropTypes.string
+  }),
+  intl: intlShape.isRequired
+};
+
+ListItemUploads.defaultProps = {
+  upload: {}
+};
+
+export default injectIntl(ListItemUploads);

--- a/components/Logs/Logs.js
+++ b/components/Logs/Logs.js
@@ -1,0 +1,38 @@
+import React from "react";
+// import { FormattedMessage } from "react-intl";
+import PropTypes from "prop-types";
+import {
+  Bullseye
+} from "@patternfly/react-core";
+import Loading from "../Loading/Loading";
+
+class Logs extends React.PureComponent {
+  render() {
+    let logSection;
+    if (this.props.fetchingLog) {
+      logSection = (
+        <Bullseye>
+          <Loading />
+        </Bullseye>
+      );
+    } else logSection = <pre className="pf-u-px-lg pf-u-py-md">{this.props.logContent}</pre>;
+    
+    return (
+      <>
+        {logSection}
+      </>
+    );
+  }
+}
+
+Logs.propTypes = {
+    fetchingLog: PropTypes.bool,
+    logContent: PropTypes.string
+  };
+  
+  Logs.defaultProps = {
+    fetchingLog: false,
+    logContent: ""
+  };
+
+export default Logs;

--- a/pages/blueprint/index.js
+++ b/pages/blueprint/index.js
@@ -18,8 +18,8 @@ import StopBuild from "../../components/Modal/StopBuild";
 import DeleteImage from "../../components/Modal/DeleteImage";
 import EmptyState from "../../components/EmptyState/EmptyState";
 import BlueprintToolbar from "../../components/Toolbar/BlueprintToolbar";
-import ListView from "../../components/ListView/ListView";
 import ListItemImages from "../../components/ListView/ListItemImages";
+import ImagesDataList from "../../components/ListView/ImagesDataList";
 import TextInlineEdit from "../../components/Form/TextInlineEdit";
 import {
   fetchingBlueprintContents,
@@ -558,17 +558,16 @@ class BlueprintPage extends React.Component {
                   <CreateImage blueprint={blueprint} layout={this.layout} />
                 </EmptyState>
               )) || (
-                <ListView className="cmpsr-images" stacked>
+                <ImagesDataList ariaLabel={formatMessage(messages.imagesTitle)}>
                   {composeList.map(compose => (
                     <ListItemImages
-                      listItemParent="cmpsr-images"
                       blueprint={this.props.route.params.blueprint}
                       listItem={compose}
                       downloadUrl={this.downloadUrl(compose)}
                       key={compose.id}
                     />
                   ))}
-                </ListView>
+                </ImagesDataList>
               )}
             </div>
           </Tab>

--- a/public/custom.css
+++ b/public/custom.css
@@ -375,7 +375,7 @@ the "-" that would display instead of the sr-only "to" */
   flex-basis: 55%;
 }
 
-.cmpsr-images__status .pficon-in-progress {
+.cc-c-data-list__item-status .pficon-in-progress {
   -webkit-animation: 1s infinite linear rotate;
           animation: 1s infinite linear rotate;
 }
@@ -597,12 +597,6 @@ textarea.form-control[readonly] {
   color: inherit;
 }
 
-.list-pf-container.image-container {
-  position: sticky;
-  top: 0;
-  background: #fff;
-}
-
 /* PF4 styles for PF3 classes */
 body {
   background: var(--pf-global--BackgroundColor--100);
@@ -632,11 +626,45 @@ body {
   --pf-c-data-list__item-action--PaddingBottom: var(--pf-global--spacer--sm);
 }
 
+.pf-c-data-list__item-row.cc-m-sticky {
+  position: sticky;
+  top: 0;
+  background: #fff;
+  border-bottom: var(--pf-c-data-list__item-item--BorderTopWidth) solid var(--pf-c-data-list__item-item--BorderTopColor);
+}
+.pf-c-data-list__expandable-content pre {
+  border-top: none;
+}
+
+.cc-u-not-visible {
+  visibility: hidden !important;
+} /* used to visually hide elements, but still retain the spacing that they take up */
+  /* use this with aria-hidden to also hide from assistive technologies */
+
+/* expand buttons are included for all nodes, but only visible for nodes with children */
+.pf-c-data-list__item-control[aria-hidden="true"] .pf-c-button {
+  visibility: hidden;
+} 
+
 .cc-c-data-list__item-icon {
   flex: 0 0 1rem;
   margin-right: var(--pf-c-data-list__item-control--MarginRight);
   padding-top: var(--pf-c-data-list__cell--PaddingTop);
 } /* sets size and spacing for custom icon column */
+
+.cc-c-status {
+  display: grid;
+  grid-row-gap: var(--pf-global--spacer--md);
+  grid-column-gap: var(--pf-global--spacer--sm);
+  grid-template-columns: minmax(var(--pf-global--icon--FontSize--md) , min-content) auto;
+}
+.cc-c-status .cc-m-full-width {
+  grid-column-start: 1;
+  grid-column-end: 3;
+}
+.cc-c-status__icon {
+  justify-self: center;
+}
 
 .pf-c-data-list__item-action.cc-m-nowrap {
     flex-wrap: nowrap;
@@ -710,6 +738,31 @@ body {
   overflow: hidden;
   text-overflow: ellipsis;
   flex: 0 0 30%;
+
+} /* sets spacing for icon column */
+
+/* modifies default datalist styles to always have contents in this element stacked */
+.pf-c-data-list__item-content.cc-m-stacked {
+  display: grid;
+  width: 100%;
+  padding-top: var(--pf-c-data-list__cell--PaddingTop);
+  padding-bottom: var(--pf-global--spacer--md);
+  grid-gap: var(--pf-global--spacer--md);
+}
+.pf-c-data-list__item-content.cc-m-stacked .pf-c-data-list__cell {
+  padding-top: 0 !important;
+  padding-bottom: 0;
+  grid-column: unset;
+  grid-column-start: 1;
+}
+@media screen and (min-width: 54rem) {
+  .pf-c-data-list__item-content.cc-m-split-on-lg {
+    grid-template-columns: 50% 50%;
+    grid-gap: var(--pf-global--spacer--xs);
+  }
+  .pf-c-data-list__item-content.cc-m-split-on-lg .pf-c-data-list__cell:last-child {
+    grid-column-start: 2;
+  }
 }
 
 @font-face {

--- a/test/end-to-end/pages/ViewBlueprint.page.js
+++ b/test/end-to-end/pages/ViewBlueprint.page.js
@@ -131,7 +131,7 @@ class ViewBlueprintPage {
   }
 
   get imageNameLabel() {
-    return $(".cmpsr-images .list-pf-title").element();
+    return $('[data-image-name]').element();
   }
 
   imageTypeLabel(type) {
@@ -139,7 +139,7 @@ class ViewBlueprintPage {
   }
 
   get completeLabel() {
-    return $("span=Complete");
+    return $('[data-status]').element();
   }
 
   waitForImageBuildComplete() {
@@ -154,19 +154,19 @@ class ViewBlueprintPage {
   }
 
   get completeIcon() {
-    return $(".cmpsr-images .pficon-ok").element();
+    return $('[data-list="images"] .pficon-ok').element();
   }
 
   get imageMoreButton() {
-    return $(".cmpsr-images .fa-ellipsis-v").element();
+    return $('[data-list="images"] .fa-ellipsis-v').element();
   }
 
   get deleteItem() {
-    return $("span=Delete").element();
+    return $('[data-delete]').element();
   }
 
   get imageDownloadButton() {
-    return $('.list-pf-actions [download=""]').element();
+    return $('[data-download]').element();
   }
 }
 

--- a/test/end-to-end/specs/imageBuilding.test.js
+++ b/test/end-to-end/specs/imageBuilding.test.js
@@ -58,6 +58,9 @@ describe("View Blueprint Page", function() {
     toastNotificationPage.closeButton.click();
     $(toastNotificationPage.containerSelector).waitForExist(timeout, true);
     viewBlueprintPage.imagesTab.click();
+
+    // show actions menu
+    viewBlueprintPage.imageMoreButton.click();
   });
 
   after(function() {
@@ -91,7 +94,7 @@ describe("View Blueprint Page", function() {
     // set test timeout to 20 minutes for image building case ONLY
     this.timeout(timeout * 10);
     viewBlueprintPage.waitForImageBuildComplete();
-    expect(viewBlueprintPage.completeLabel.getText()).to.equal("Complete");
+    expect(viewBlueprintPage.completeLabel.getText()).to.equal("Image build complete");
   });
 
   it("should show correct Complete icon", function() {
@@ -119,6 +122,7 @@ describe("View Blueprint Page", function() {
 
   describe("Delete Image Page", function() {
     before(function() {
+      viewBlueprintPage.imagesTab.click();
       viewBlueprintPage.imageMoreButton.click();
       viewBlueprintPage.deleteItem.click();
       deleteImagePage.loading();


### PR DESCRIPTION
This is a duplicate of #846 except that it is based on master instead of #767.

- Updates text strings based on [latest design](https://docs.google.com/presentation/d/1LCvefUG_a3o4M2Cf4xbhtNHEeyJJ2uzfQpmycKEBJHY/edit?usp=sharing) and moves most of them to the beginning of the file
- Adds image size to the image list item
- Migrates list of images to PF4 data list component and makes layout updates based on [latest design](https://docs.google.com/presentation/d/1LCvefUG_a3o4M2Cf4xbhtNHEeyJJ2uzfQpmycKEBJHY/edit?usp=sharing)
- Moves Logs contents to a separate component for future use with Uploads list