### PR TITLE
test: Lock webdriverio and all wdio relate version to 5.16

### DIFF
--- a/test/end-to-end/package.json
+++ b/test/end-to-end/package.json
@@ -13,18 +13,18 @@
     "faker": "^4.1.0",
     "path": "^0.12.7",
     "wdio-timeline-reporter": "^5.1.2",
-    "webdriverio": "^5.16.6"
+    "webdriverio": "5.16.6"
   },
   "devDependencies": {
     "@babel/cli": "^7.7.0",
     "@babel/core": "^7.7.2",
     "@babel/preset-env": "^7.7.1",
     "@babel/register": "^7.7.0",
-    "@wdio/cli": "^5.16.6",
+    "@wdio/cli": "5.16.6",
     "@wdio/junit-reporter": "^5.15.5",
-    "@wdio/local-runner": "^5.16.6",
-    "@wdio/mocha-framework": "^5.16.5",
-    "@wdio/spec-reporter": "^5.16.5",
-    "@wdio/sync": "^5.16.5"
+    "@wdio/local-runner": "5.16.6",
+    "@wdio/mocha-framework": "5.16.5",
+    "@wdio/spec-reporter": "5.16.5",
+    "@wdio/sync": "5.16.5"
   }
 }


### PR DESCRIPTION
The latest webdriver.io release(v5.18.3) brings a bug https://github.com/webdriverio/webdriverio/issues/4934. This issue will cause 'non W3C properties' error. Solution is locking webdriver.io to 5.16 until issue got fixed.