### PR TITLE
cockpituous: remove releases except for fedora-31

### DIFF
--- a/utils/cockpituous-release
+++ b/utils/cockpituous-release
@@ -18,11 +18,9 @@ job release-srpm -V
 # Do fedora builds for the tag, using tarball
 job release-koji master
 job release-koji f31
-job release-koji f30
 
 job release-github
 job release-copr @weldr/cockpit-composer
 
 # Create a Bodhi update for stable Fedora releases
 job release-bodhi F31
-job release-bodhi F30


### PR DESCRIPTION
As part of the move to using osbuild-composer instead of lorax, we should only release on fedora-31 since the other distros will fail to install osbuild-composer. This PR is required for #868 