### PR TITLE
test: Use both "admin" and "root" as user name to run tests

### DIFF
--- a/test/end-to-end/utils/commands.js
+++ b/test/end-to-end/utils/commands.js
@@ -32,8 +32,7 @@ module.exports = {
     }
   },
 
-  login: function() {
-    const username = process.env.COCKPIT_USERNAME || "admin";
+  login: function(username) {
     const password = process.env.COCKPIT_PASSWORD || "foobar";
 
     browser.url("/composer");

--- a/test/end-to-end/wdio.conf.js
+++ b/test/end-to-end/wdio.conf.js
@@ -250,11 +250,15 @@ exports.config = {
       browser.setWindowSize(1280, 1024);
     }
     // login cockpit and enter into composer page
-    browser.login();
-    browser.switchToComposerFrame();
-    // only the first suite needs start lorax-composer
+    // only api related test uses "admin" as user name
+    // the rest of suites will use "root"
     if (suite.title === "lorax-composer api sanity test") {
+      browser.login(process.env.COCKPIT_USERNAME || "admin");
+      browser.switchToComposerFrame();
       browser.startLoraxIfItDoesNotStart();
+    } else {
+      browser.login(process.env.COCKPIT_USERNAME || "root");
+      browser.switchToComposerFrame();
     }
   },
   /**


### PR DESCRIPTION
To cover both root and non-root login scenario, only api related tests use "admin" as login user and the other tests use "root"