### PR TITLE
cockpituous: Release to Fedora 32

### DIFF
--- a/utils/cockpituous-release
+++ b/utils/cockpituous-release
@@ -18,9 +18,11 @@ job release-srpm -V
 # Do fedora builds for the tag, using tarball
 job release-koji master
 job release-koji f31
+job release-koji f32
 
 job release-github
 job release-copr @weldr/cockpit-composer
 
 # Create a Bodhi update for stable Fedora releases
 job release-bodhi F31
+job release-bodhi F32


### PR DESCRIPTION
It branched off on Feb 11:
https://fedorapeople.org/groups/schedule/f-32/f-32-key-tasks.html