### PR TITLE
test: Always explicitly install lorax-composer

### DIFF
--- a/test/vm.install
+++ b/test/vm.install
@@ -3,10 +3,8 @@
 # The application RPM will be installed separately
 set -eux
 
-# Update lorax-composer using the updates-testing repository
-if grep -isq fedora /etc/redhat-release && grep -isq firefox /tmp/BROWSER; then
-    dnf install -y lorax-composer --enablerepo=updates-testing
-fi
+# Explicitly install lorax-composer for now, we want to test against that, not osbuild yet
+dnf install -y lorax-composer
 
 # Allow cockpit port (9090) in INPUT chain
 # Do not reload firewall rule during image generation


### PR DESCRIPTION
In Fedora, golang-github-osbuild-composer Provides: lorax-composer, but
does not currently fully replace it (e. g. it doesn't provide
lorax-composer.service). Also, we want to be explicit about which
backend we test against. So always explicitly install lorax-composer for
now.

In the future, we can add another scenario that tests against osbuild,
but that needs slightly different setup.